### PR TITLE
Fix unexpected operator when running sudo make toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(PHOTON_TOOLCHAIN): check $(PHOTON_STAGE)
 else
 
 $(PHOTON_TOOLCHAIN): $(PHOTON_STAGE) $(PHOTON_SOURCES)
-	@if [ -a $(PHOTON_TOOLCHAIN) ] ; then \
+	@if [ -f $(PHOTON_TOOLCHAIN) ] ; then \
 		echo "Using already built toolchain"; \
 	else \
 		echo "Building toolchain..."; \


### PR DESCRIPTION
This p-r fixes following error:

```
sudo make toolchain
~
Downloading zlib-1.2.8.tar.xz...
/bin/sh: 1: [: -a: unexpected operator
Building toolchain...
Clean directory: /mnt/photonroot: SUCCESS
```

If you use bash as /bin/sh, above error doesn't appear.