### PR TITLE
systemd: Fix systemd-networkd-wait-online hangs with multiple NICs

### DIFF
--- a/SPECS/systemd/systemd-216-fix-systemd-networkd-wait-online-with-multiple-nics.patch
+++ b/SPECS/systemd/systemd-216-fix-systemd-networkd-wait-online-with-multiple-nics.patch
@@ -1,0 +1,29 @@
+Submitted By:            Yuya Kusakabe <kusakabe.yuya@nifty.co.jp>
+Date:                    2015-04-25
+Initial Package Version: 216
+Upstream Status:         Not applicable
+Origin:                  Based on mischief's patch at
+  http://lists.freedesktop.org/archives/systemd-devel/2015-March/029858.html
+Description:             when checking interface status, systemd-networkd-wait-online
+                         will continue to wait if any interface is still configuring or
+                         being processed by udev. this patch allows it to return if any
+                         one interface is degraded/routable, as per the manual.
+
+--- a/src/network/networkd-wait-online-manager.c	2014-07-22 07:37:55.858846879 +0900
++++ b/src/network/networkd-wait-online-manager.c	2015-04-25 19:42:04.636202190 +0900
+@@ -57,13 +57,13 @@
+                 if (!l->state) {
+                         log_debug("link %s has not yet been processed by udev",
+                                   l->ifname);
+-                        return false;
++                        continue;
+                 }
+ 
+                 if (streq(l->state, "configuring")) {
+                         log_debug("link %s is being processed by networkd",
+                                   l->ifname);
+-                        return false;
++                        continue;
+                 }
+ 
+                 if (l->operational_state &&

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:	Systemd-216
 Name:		systemd
 Version:	216
-Release:	10%{?dist}
+Release:	11%{?dist}
 License:	LGPLv2+ and GPLv2+ and MIT
 URL:		http://www.freedesktop.org/wiki/Software/systemd/
 Group:		System Environment/Security
@@ -11,6 +11,7 @@ Source0:	http://www.freedesktop.org/software/systemd/%{name}-%{version}.tar.xz
 %define sha1 systemd=0d933a2f76db5d30f52429e9b172323bc6abd49a
 Patch0:     	systemd-216-compat-1.patch
 Patch1:		01-enoX-uses-instance-number-for-vmware-hv.patch
+Patch2:     systemd-216-fix-systemd-networkd-wait-online-with-multiple-nics.patch
 Requires:	Linux-PAM
 Requires:	libcap
 Requires:	xz
@@ -95,6 +96,8 @@ rm -rf %{buildroot}/*
 
 
 %changelog
+*	Fri Oct 2 2015 Yuya Kusakabe <yuya.kusakabe@gmail.com> 216-11
+-	systemd: Fix systemd-networkd-wait-online hangs with multiple NICs
 *	Tue Sep 10 2015 Alexey Makhalov <amakhalov@vmware.com> 216-10
 -	Improve enoX renaming in VMware HV case. Patch is added.
 *	Tue Aug 25 2015 Alexey Makhalov <amakhalov@vmware.com> 216-9


### PR DESCRIPTION
Fixes #24.

This p-r is based on mischief's patch at http://lists.freedesktop.org/archives/systemd-devel/2015-March/029858.html.

My testing rpms are here: https://github.com/higebu/photon/releases/tag/systemd-216-2