### PR TITLE
Fix delta rpm package to include python libs in package.

### DIFF
--- a/SPECS/deltarpm/deltarpm.spec
+++ b/SPECS/deltarpm/deltarpm.spec
@@ -1,19 +1,25 @@
 Summary: Create deltas between rpms
 Name: deltarpm
 Version: 3.6
-Release: 1
+Release: 2
 License: BSD
 Group: Applications/System
-Vendor:		VMware, Inc.
+Vendor: VMware, Inc.
 Distribution: Photon
 URL: http://www.novell.com/products/linuxpackages/professional/deltarpm.html
 Source0: ftp://ftp.suse.com/pub/projects/deltarpm/deltarpm-%{version}.tar.bz2
 BuildRequires: rpm-devel >= 4.2
 BuildRequires: bzip2-devel
-Requires: perl
 BuildRequires: xz-devel
 BuildRequires: popt-devel
 BuildRequires: python2
+BuildRequires: python2-libs
+BuildRequires: python2-devel
+Requires: perl
+Requires: python2
+Requires: python2-libs
+
+
 %description
 A deltarpm contains the difference between an old
 and a new version of a rpm, which makes it possible
@@ -53,8 +59,12 @@ deltarpms can also work with installed rpms.
 %{_bindir}/makedeltarpm
 %{_bindir}/rpmdumpheader
 %{_bindir}/fragiso
+%{python_sitelib}/*
 
 %changelog
+* Tue Apr 28 2015 Fabio Rapposelli <fabio@vmware.com> - 3.6-2
+- Fixed Python install.
+
 * Fri Mar 09 2007 Dag Wieers <dag@wieers.com> - 3.3-2
 - Fixed group.
 


### PR DESCRIPTION
This PR adds the missing python lib for `deltarpm`, fixes #23 