### PR TITLE
GCC sec options (PIE support) + minor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ iso: check $(PHOTON_PACKAGES) $(PHOTON_TOOLCHAIN_MINIMAL)
                         -f > \
         $(PHOTON_LOGS_DIR)/installer.log 2>&1
 
-packages: check $(PHOTON_TOOLCHAIN) $(PHOTON_SOURCES)
+packages: check $(PHOTON_TOOLCHAIN_MINIMAL) $(PHOTON_SOURCES)
 	@echo "Building all RPMS..."
 	@cd $(PHOTON_PKG_BUILDER_DIR) && \
     $(PHOTON_PACKAGE_BUILDER) -a \
@@ -43,7 +43,7 @@ packages: check $(PHOTON_TOOLCHAIN) $(PHOTON_SOURCES)
                               -p $(PHOTON_STAGE) \
                               -l $(PHOTON_LOGS_DIR)
 
-packages-cached: check $(PHOTON_TOOLCHAIN)
+packages-cached: check $(PHOTON_TOOLCHAIN_MINIMAL)
 	@echo "Using cached RPMS..."
 	@$(RM) -f $(PHOTON_RPMS_DIR_NOARCH)/* && \
      $(RM) -f $(PHOTON_RPMS_DIR_X86_64)/* && \

--- a/SPECS/createrepo/createrepo.spec
+++ b/SPECS/createrepo/createrepo.spec
@@ -17,7 +17,7 @@ Requires: bash
 Requires: deltarpm
 BuildRequires: bash
 BuildRequires: deltarpm
-BuildRequires: yum-metadata-parser, yum, python2, rpm-devel, rpm, libxml2, python2, python2-libs
+BuildRequires: yum-metadata-parser, yum, rpm-devel, rpm, libxml2, python2, python2-libs
 %description
 This utility will generate a common metadata repository from a directory of
 rpm packages

--- a/SPECS/elfutils/elfutils.spec
+++ b/SPECS/elfutils/elfutils.spec
@@ -99,7 +99,7 @@ for libelf.
 
 %build
 %configure --program-prefix=%{_programprefix}
-make
+make %{?_smp_mflags}
 
 %install
 rm -rf ${RPM_BUILD_ROOT}

--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -44,7 +44,7 @@ install -vdm 755 %{buildroot}/var/{opt,cache,lib/{color,misc,locate},local}
 #	6.6. Creating Essential Files and Symlinks
 #
 ln -sv /proc/self/mounts %{buildroot}/etc/mtab
-touch %{buildroot}/etc/mtab
+#touch -f %{buildroot}/etc/mtab
 touch %{buildroot}/var/log/{btmp,lastlog,wtmp}
 #
 #	Configuration files
@@ -96,7 +96,6 @@ systemd-timesync:x:78:
 nogroup:x:99:
 users:x:999:
 EOF
-touch %{buildroot}/etc/mtab
 #
 #	7.2.2. Creating Network Interface Configuration Files"
 #

--- a/SPECS/nss/nss.spec
+++ b/SPECS/nss/nss.spec
@@ -35,6 +35,7 @@ Header files for doing development with Network Security Services.
 %patch -p1
 %build
 cd nss
+# -j is not supported by nss
 make VERBOSE=1 BUILD_OPT=1 \
 	NSPR_INCLUDE_DIR=%{_includedir}/nspr \
 	USE_SYSTEM_ZLIB=1 \

--- a/SPECS/open-vm-tools/open-vm-tools-service-link.patch
+++ b/SPECS/open-vm-tools/open-vm-tools-service-link.patch
@@ -1,0 +1,11 @@
+--- open-vm-tools-9.10.0/vgauth/service/Makefile.in	2015-03-19 11:11:07.000000000 -0700
++++ open-vm-tools-9.10.0/vgauth/service/Makefile.in_	2015-05-12 16:01:37.695680243 -0700
+@@ -322,7 +322,7 @@
+ 	../lib/libvgauth.la @XERCES_LIBS@ @XMLSECURITY_LIBS@ \
+ 	@SSL_LIBS@ -lxerces-c -lxml-security-c -lssl -lcrypto \
+ 	$(am__append_1)
+-@HAVE_ICU_FALSE@VGAuthService_LINK = $(LINK)
++@HAVE_ICU_FALSE@VGAuthService_LINK = $(CXXLINK)
+ @HAVE_ICU_TRUE@VGAuthService_LINK = $(LIBTOOL) --tag=CXX $(AM_LIBTOOLFLAGS)     \
+ @HAVE_ICU_TRUE@                            $(LIBTOOLFLAGS) --mode=link $(CXX)       \
+ @HAVE_ICU_TRUE@                            $(AM_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \

--- a/SPECS/open-vm-tools/open-vm-tools.spec
+++ b/SPECS/open-vm-tools/open-vm-tools.spec
@@ -9,6 +9,7 @@ Vendor:		VMware, Inc.
 Distribution:	Photon
 Source0:	http://downloads.sourceforge.net/project/open-vm-tools/open-vm-tools/stable-9.10.0/%{name}-%{version}.tar.gz
 Patch0:		open-vm-tools-glibc-fixes.patch
+Patch1:		open-vm-tools-service-link.patch
 BuildRequires: 	glib-devel
 BuildRequires: 	xerces-c-devel
 BuildRequires: 	xml-security-c-devel
@@ -28,6 +29,7 @@ VmWare virtualization user mode tools
 %prep
 %setup -q
 %patch0 -p1
+%patch1 -p1
 %build
 export CFLAGS="$RPM_OPT_FLAGS -Wno-unused-local-typedefs -Wno-deprecated-declarations -D_DEFAULT_SOURCE"
 export CXXFLAGS="$RPM_OPT_FLAGS -Wno-unused-local-typedefs -Wno-deprecated-declarations -D_DEFAULT_SOURCE"

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -35,6 +35,7 @@ export CFLAGS="%{optflags}"
 	shared \
 	zlib-dynamic \
 	-Wa,--noexecstack "${CFLAGS}" "${LDFLAGS}"
+# does not support -j yet
 make
 %install
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*

--- a/SPECS/urlgrabber/urlgrabber.spec
+++ b/SPECS/urlgrabber/urlgrabber.spec
@@ -17,6 +17,7 @@ BuildRequires:  	pycurl
 BuildRequires:		python2
 BuildRequires:		python2-libs
 Requires:		python2
+Requires:		curl
 
 %description
 A high-level cross-protocol url-grabber for python supporting HTTP, FTP 

--- a/support/package-builder/adjust-gcc-specs.sh
+++ b/support/package-builder/adjust-gcc-specs.sh
@@ -1,23 +1,27 @@
 #! /bin/bash
 
-if [ $# -eq 1 -a $1 = "clean" ]; then
-    rm -f `dirname $(/usr/bin/gcc --print-libgcc-file-name)`/specs
+if [ $# -eq 1 -a "x$1" = "xclean" ]; then
+    rm -f `dirname $(gcc --print-libgcc-file-name)`/../specs
     exit 0
 fi
 
-cat <<EOF > `dirname $(/usr/bin/gcc --print-libgcc-file-name)`/specs
+cat <<EOF > `dirname $(gcc --print-libgcc-file-name)`/../specs
 *cc1:
-+ %{!fno-stack-protector:-fstack-protector} %{fno-pie|fno-PIE|fpic|fPIC|shared:;:-fPIE} 
++ %{!fno-stack-protector:-fstack-protector} %{fno-pie|fno-PIE|fpic|fPIC|shared:;:-fPIE -fpie}
 
 *cc1plus:
-+ %{!fno-stack-protector:-fstack-protector} %{fno-pie|fno-PIE|fpic|fPIC|shared:;:-fPIE} 
++ %{!fno-stack-protector:-fstack-protector} %{fno-pie|fno-PIE|fpic|fPIC|shared:;:-fPIE -fpie}
 
 *cpp:
 + %{O1|O2|O3|Os|Ofast:-D_FORTIFY_SOURCE=2}
 
 *link:
-+ %{!norelro:-z relro} %{!nonow:-z now}
++ %{r|fno-pie|fno-PIE|fpic|fPIC|fno-pic|fno-PIC|shared:;:-pie} %{!norelro:-z relro} %{!nonow:-z now}
 
 *libgcc:
 + -lgcc_s
+
+*startfile:
+%{!mandroid|tno-android-ld:%{!shared: %{pg|p|profile:gcrt1.o%s;:Scrt1.o%s}}    crti.o%s %{static:crtbeginT.o%s;:crtbeginS.o%s};:%{shared: crtbegin_so%O%s;:  %{static: crtbegin_static%O%s;: crtbegin_dynamic%O%s}}}
+
 EOF

--- a/support/package-builder/common.inc
+++ b/support/package-builder/common.inc
@@ -32,7 +32,7 @@ run_command() {
 		eval ${_cmd} >> ${_logfile} 2>&1 && print_succeeded_in_green || print_failed_in_red
 	else
 		print_message "${_msg}: "
-		printf "\n%s\n\n" "###       ${_msg}       ###" >> ${_logfile} 2>&1
+		printf "\n%s\ncmd: %s\n\n" "###       ${_msg}       ###" "${_cmd}" >> ${_logfile} 2>&1
 		eval ${_cmd} >> ${_logfile} 2>&1 && print_succeeded_in_green || print_failed_in_red
 		fi
 	return 0

--- a/support/package-builder/prepare-build-root.sh
+++ b/support/package-builder/prepare-build-root.sh
@@ -23,9 +23,9 @@ BUILDROOT=$1
 SPEC_PATH=$2
 RPM_PATH=$3
 TOOLS_PATH=$4
+TOOLS_ARCHIVE=$5
 PARENT=/usr/src/photon
 rm -rf ${BUILDROOT}/*
-rm -rf /tools
 
 #LOGFILE=/dev/null		#	uncomment to disable log file
 [ ${EUID} -eq 0 ] 	|| fail "${PRGNAME}: Need to be root user: FAILURE"
@@ -47,15 +47,17 @@ if mountpoint ${BUILDROOT}/dev	>/dev/null 2>&1; then umount ${BUILDROOT}/dev; fi
 #Untar tools build to buildroot
 #
 
-echo "Uncompressing the tools tar"
-
-tar -C ${BUILDROOT} -xvf $TOOLS_PATH/tools-build.tar >/dev/null
-# YUSTAS_FIXME: rpm still depends on /tools/lib/... Remove this dependency.
-ln -sf ${BUILDROOT}/tools /tools
+if [ "x$TOOLS_ARCHIVE" = "xminimal" ] ; then
+    echo "Uncompressing the tools tar (minimal)"
+    tar -C ${BUILDROOT} -xzf $TOOLS_PATH/tools.tar.gz >/dev/null
+else
+    echo "Uncompressing the tools tar"
+    tar -C ${BUILDROOT} -xf $TOOLS_PATH/tools-build.tar >/dev/null
+fi
 
 mkdir -p ${BUILDROOT}/tmp
 mkdir -p ${BUILDROOT}${PARENT}
-mkdir -p ${BUILDROOT}${PARENT}/RPMS
+mkdir -p ${BUILDROOT}${PARENT}/RPMS/x86_64
 mkdir -p ${BUILDROOT}${PARENT}/BUILD
 mkdir -p ${BUILDROOT}${PARENT}/BUILDROOT
 mkdir -p ${BUILDROOT}${PARENT}/LOGS
@@ -77,21 +79,24 @@ echo "%_smp_mflags -j${NUMPROCS}" >> ${BUILDROOT}/tools/etc/rpm/macros
 #	Setup the filesystem for chapter 06
 RPMPKG="$(find $RPM_PATH -name 'filesystem*.rpm' -print)"
 if [ -z ${RPMPKG} ] ; then
-run_command "Building filesystem rpm" "${BUILDROOT}/tools/bin/rpmbuild -ba --nocheck --define \"_topdir ${BUILDROOT}/${PARENT}\" --define \"_dbpath ${BUILDROOT}/var/lib/rpm\" ${SPEC_PATH}/filesystem/filesystem.spec" "$LOG_PATH/filesystem.log"
-run_command "Extracting filesystem rpm" "cp ${BUILDROOT}/${PARENT}/RPMS/x86_64/filesystem*.rpm ${RPM_PATH}/x86_64/" "$LOG_PATH/filesystem.log"
+run_command "	Extracting filesystem spec" "cp ${SPEC_PATH}/filesystem/filesystem.spec ${BUILDROOT}/${PARENT}/SPECS" "$LOG_PATH/filesystem.log"
+# rpmbuild requires /bin/bash
+run_command "	Creating symlink: /tools/bin /bin" "ln -fsv /tools/bin ${BUILDROOT}/bin"	 "$LOG_PATH/filesystem.completed"
+run_command "	Building filesystem rpm (in chroot)" "./run-in-chroot.sh ${BUILDROOT} rpmbuild -ba --nocheck --define \\\"_topdir ${PARENT}\\\" ${PARENT}/SPECS/filesystem.spec" "$LOG_PATH/filesystem.log"
+run_command "	Removing symlink: /tools/bin /bin" "rm -f ${BUILDROOT}/bin"	 "$LOG_PATH/filesystem.completed"
+run_command "	Extracting filesystem rpm" "cp ${BUILDROOT}/${PARENT}/RPMS/x86_64/filesystem*.rpm ${RPM_PATH}/x86_64/" "$LOG_PATH/filesystem.log"
 fi
-RPMPKG="$(find $RPM_PATH -name 'filesystem*.rpm' -print)"
-[ -z ${RPMPKG} ] && fail "	Filesystem rpm package missing: Can not continue"
-run_command "	Installing filesystem" "${BUILDROOT}/tools/bin/rpm -Uvh --nodeps --root ${BUILDROOT} ${RPMPKG}" "$LOG_PATH/filesystem.completed"
+RPMPKGFILE="$(find ${RPM_PATH} -name 'filesystem*.rpm' -printf %f)"
+[ -z ${RPMPKGFILE} ] && fail "	Filesystem rpm package missing: Can not continue"
+run_command "	Copying filesystem rpm" "cp ${RPM_PATH}/x86_64/${RPMPKGFILE} ${BUILDROOT}/${PARENT}/RPMS/x86_64" "$LOG_PATH/filesystem.log"
+run_command "	Installing filesystem (in chroot)" "./run-in-chroot.sh ${BUILDROOT} rpm -Uvh --nodeps ${PARENT}/RPMS/x86_64/${RPMPKGFILE}" "$LOG_PATH/filesystem.completed"
 run_command "	Creating symlinks: /tools/bin/{bash,cat,echo,pwd,stty}" "ln -fsv /tools/bin/{bash,cat,echo,pwd,stty} ${BUILDROOT}/bin"   "$LOG_PATH/filesystem.completed"
 run_command "	Creating symlinks: /tools/bin/perl /usr/bin" "ln -fsv /tools/bin/perl ${BUILDROOT}/usr/bin" "$LOG_PATH/filesystem.completed"
 run_command "	Creating symlinks: /tools/lib/libgcc_s.so{,.1}" "ln -fsv /tools/lib/libgcc_s.so{,.1} ${BUILDROOT}/usr/lib" "$LOG_PATH/filesystem.completed"
 run_command "	Creating symlinks: /tools/lib/libstdc++.so{,.6} /usr/lib" "ln -fsv /tools/lib/libstdc++.so{,.6} ${BUILDROOT}/usr/lib"	 "$LOG_PATH/filesystem.completed"
-run_command "	Sed: /usr/lib/libstdc++.la" "sed 's/tools/usr/' ${BUILDROOT}/tools/lib/libstdc++.la > ${BUILDROOT}/usr/lib/libstdc++.la" "$LOG_PATH/filesystem.completed"
+[ -z $TOOLS_ARCHIVE ] && \
+    run_command "	Sed: /usr/lib/libstdc++.la" "sed 's/tools/usr/' ${BUILDROOT}/tools/lib/libstdc++.la > ${BUILDROOT}/usr/lib/libstdc++.la" "$LOG_PATH/filesystem.completed"
 run_command "	Creating symlinks: bash /bin/sh" "ln -fsv bash ${BUILDROOT}/bin/sh" "$LOG_PATH/filesystem.completed"
-# YUSTAS_FIXME: Add security flags for toolchain
-#run_command "	Adding spec file for gcc #1" "cp ${TOOLS_PATH}/../support/toolchain/gcc_specs ${BUILDROOT}/tools/lib/gcc/x86_64-unknown-linux-gnu/4.8.2/specs" "$LOG_PATH/filesystem.completed"
-#run_command "	Adding spec file for gcc #2" "cp ${TOOLS_PATH}/../support/toolchain/gcc_specs ${BUILDROOT}/tools/lib/gcc/x86_64-photon-linux-gnu/4.8.2/specs" "$LOG_PATH/filesystem.completed"
 
 # 	Ommited in the filesystem.spec file - not needed for booting
 [ -e ${BUILDROOT}/dev/console ]	|| mknod -m 600 ${BUILDROOT}/dev/console c 5 1

--- a/support/package-builder/run-in-chroot.sh
+++ b/support/package-builder/run-in-chroot.sh
@@ -26,8 +26,8 @@ shift
 PHOTON_ENV_CMD=/usr/bin/env
 PHOTON_BASH_CMD=/bin/bash
 
-test -x /tools/bin/env && PHOTON_ENV_CMD=/tools/bin/env
-test -x /tools/bin/bash && PHOTON_BASH_CMD=/tools/bin/bash
+test -x ${BUILDROOT}/tools/bin/env && PHOTON_ENV_CMD=/tools/bin/env
+test -x ${BUILDROOT}/tools/bin/bash && PHOTON_BASH_CMD=/tools/bin/bash
 
 #
 #	Goto chroot and run the command specified as parameter.

--- a/support/toolchain/mk-tools.sh
+++ b/support/toolchain/mk-tools.sh
@@ -933,8 +933,8 @@ build-libstdc++
 build-binutils2
 build-gcc2
 build-tcl
-build-expect
-build-dejagnu
+#build-expect
+#build-dejagnu
 build-check
 build-ncurses
 build-bash
@@ -966,10 +966,10 @@ build-elfutils
 build-rpm
 build-cpio
 #	The following are not used
-#	strip-ToolChain
+strip-ToolChain
 #	change-ownership
 msg "Creating tools tar ball"
-tar -cvhf $DESTDIR/tools-build.tar /tools
+tar -cf $DESTDIR/tools-build.tar -C ${BUILDDIR} tools
 rm -rf ${BUILDDIR}
 rm /tools
 msg "Successfully built the Toolchain"

--- a/support/toolchain/tools-minimal.list
+++ b/support/toolchain/tools-minimal.list
@@ -1,4 +1,4 @@
-tools/lib64/ld-linux-x86-64.so.2
+tools/lib64
 tools/etc/rpc
 tools/etc/rpm/macros
 tools/bin/bash
@@ -38,6 +38,7 @@ tools/lib/libsqlite3.so
 tools/lib/librpmsign.so.1
 tools/lib/libnss_nisplus.so
 tools/lib/libm.so
+tools/lib/libm-2.21.so
 tools/lib/libnss_files-2.21.so
 tools/lib/librpmsign.la
 tools/lib/libnss_nisplus.so.2
@@ -215,6 +216,7 @@ tools/lib/librt-2.21.so
 tools/lib/libplc4.so
 tools/lib/libnss_db-2.21.so
 tools/lib/liblzma.la
+tools/lib/ld-2.21.so
 tools/lib/ld-linux-x86-64.so.2
 tools/lib/libsoftokn3.so
 tools/lib/libnss_db.so


### PR DESCRIPTION
GCC sec options:
- added -pie flag + startfiles for linker.
- adjust-gcc-specs.sh cleanup.

Minor improvements:
- use minimal toolchain archive.
- package builder doesn't use host /tools anymore.
- fix createrepo build problem.
- added make -jN for some pkgs.
- patched open-vm-tools to build with -pie.
- removed 'expect' and 'dejagnu' pkgs from toolchain archive.