### PR TITLE
support for dist tag in specs

### DIFF
--- a/SPECS/Linux-PAM/Linux-PAM.spec
+++ b/SPECS/Linux-PAM/Linux-PAM.spec
@@ -1,7 +1,7 @@
 Summary:	Linux Pluggable Authentication Modules
 Name:		Linux-PAM
 Version:	1.1.8
-Release:	1
+Release:	1%{?dist}
 License:	BSD and GPLv2+
 URL:		https://www.kernel.org/pub/linux/libs/pam/
 Group:		System Environment/Security

--- a/SPECS/PyYAML/PyYAML.spec
+++ b/SPECS/PyYAML/PyYAML.spec
@@ -1,6 +1,6 @@
 Name:           PyYAML
 Version:        3.11
-Release:        1
+Release:        1%{?dist}
 Summary:        YAML parser and emitter for Python
 Group:          Development/Libraries
 License:        MIT

--- a/SPECS/XML-Parser/XML-Parser.spec
+++ b/SPECS/XML-Parser/XML-Parser.spec
@@ -1,7 +1,7 @@
 Summary:	XML-Parser perl module
 Name:		XML-Parser
 Version:	2.41
-Release:	1
+Release:	1%{?dist}
 License:	GPL+
 URL:		http://search.cpan.org/~toddr/%{name}-%{version}/
 Source0:		http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/%{name}-%{version}.tar.gz

--- a/SPECS/acl/acl.spec
+++ b/SPECS/acl/acl.spec
@@ -1,7 +1,7 @@
 Summary:	Access control list utilities
 Name:		acl
 Version:	2.2.52
-Release:	1
+Release:	1%{?dist}
 Source0:	http://download.savannah.gnu.org/releases-noredirect/acl/acl-%{version}.src.tar.gz
 License:	GPLv2+
 Group:		System Environment/Base

--- a/SPECS/attr/attr.spec
+++ b/SPECS/attr/attr.spec
@@ -1,7 +1,7 @@
 Summary:	Attr-2.4.47
 Name:		attr
 Version:	2.4.47
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		https://www.gnu.org/software/hurd/community/gsoc/project_ideas/libcap.html
 Source0:	http://download.savannah.gnu.org/releases/attr/%{name}-%{version}.src.tar.gz

--- a/SPECS/autoconf/autoconf.spec
+++ b/SPECS/autoconf/autoconf.spec
@@ -1,7 +1,7 @@
 Summary:	The package automatically configure source code
 Name:		autoconf
 Version:	2.69
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 URL:		http://www.gnu.org/software/autoconf
 Group:		System Environment/Base

--- a/SPECS/automake/automake.spec
+++ b/SPECS/automake/automake.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for generating Makefiles
 Name:		automake
 Version:	1.14.1
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.gnu.org/software/automake/
 Group:		System Environment/Base

--- a/SPECS/bash/bash.spec
+++ b/SPECS/bash/bash.spec
@@ -1,7 +1,7 @@
 Summary:	Bourne-Again SHell
 Name:		bash
 Version:	4.3
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3
 URL:		http://www.gnu.org/software/bash/
 Group:		System Environment/Base

--- a/SPECS/bc/bc.spec
+++ b/SPECS/bc/bc.spec
@@ -1,7 +1,7 @@
 Summary:	precision numeric processing language
 Name:		bc
 Version:	1.06.95
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://alpha.gnu.org/gnu/bc/
 Group:		System Environment/base

--- a/SPECS/bindutils/bindutils.spec
+++ b/SPECS/bindutils/bindutils.spec
@@ -1,7 +1,7 @@
 Summary:	Domain Name System software
 Name:		bindutils
 Version:	9.10.1
-Release:	P1
+Release:	P1%{?dist}
 License:	ISC
 URL:		http://www.isc.org/downloads/bind/
 Source0:	ftp://ftp.isc.org/isc/bind9/9.10.1-P1/bind-%{version}-%{release}.tar.gz

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -1,7 +1,7 @@
 Summary:	Contains a linker, an assembler, and other tools
 Name:		binutils
 Version:	2.25
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.gnu.org/software/binutils
 Group:		System Environment/Base

--- a/SPECS/bison/bison.spec
+++ b/SPECS/bison/bison.spec
@@ -1,7 +1,7 @@
 Summary:	Contains a parser generator
 Name:		bison
 Version:	3.0.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/bison
 Group:		System Environment/Base

--- a/SPECS/boost/boost.spec
+++ b/SPECS/boost/boost.spec
@@ -1,7 +1,7 @@
 Summary:	Boost 
 Name:		boost
 Version:	1.56.0
-Release:	1
+Release:	1%{?dist}
 License:	Boost Software License V1
 URL:		http://www.boost.org/
 Group:		System Environment/Security

--- a/SPECS/bridge-utils/bridge-utils.spec
+++ b/SPECS/bridge-utils/bridge-utils.spec
@@ -1,7 +1,7 @@
 Summary:	Utilities for configuring and managing bridge devices
 Name:		bridge-utils
 Version:	1.5
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.linuxfoundation.org/collaborate/workgroups/networking/bridge
 Group:		System Environment/Base

--- a/SPECS/btrfs-progs/btrfs-progs.spec
+++ b/SPECS/btrfs-progs/btrfs-progs.spec
@@ -1,6 +1,6 @@
 Name:		btrfs-progs
 Version:	3.18.2
-Release:	1
+Release:	1%{?dist}
 Summary:	Userspace programs for btrfs
 Group:		System Environment/Base
 License:	GPLv2+

--- a/SPECS/bzip2/bzip2.spec
+++ b/SPECS/bzip2/bzip2.spec
@@ -1,7 +1,7 @@
 Summary:	Contains programs for compressing and decompressing files
 Name:		bzip2
 Version:	1.0.6
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://www.bzip.org/
 Group:		System Environment/Base

--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -1,7 +1,7 @@
 Summary:	Certificate Authority certificates 
 Name:		ca-certificates
 Version:	20130524
-Release:	1
+Release:	1%{?dist}
 License:	Custom
 URL:		http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/
 Group:		System Environment/Security

--- a/SPECS/cdrkit/cdrkit.spec
+++ b/SPECS/cdrkit/cdrkit.spec
@@ -1,7 +1,7 @@
 Summary: 	Utilities for writing cds.
 Name: 		cdrkit
 Version: 	1.1.11
-Release: 	1
+Release: 	1%{?dist}
 License: 	GPLv2+
 Group: 		System Environment/Base
 Vendor:		VMware, Inc.

--- a/SPECS/check/check.spec
+++ b/SPECS/check/check.spec
@@ -1,7 +1,7 @@
 Summary:	Check-0.9.14
 Name:		check
 Version:	0.9.14
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 URL:		http://check.sourceforge.net/
 Source0:	http://sourceforge.net/projects/check/files/latest/download/%{name}-%{version}.tar.gz

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,6 +1,6 @@
 Name:           cloud-init
 Version:        0.7.6
-Release:        1
+Release:        1%{?dist}
 Summary:        Cloud instance init scripts
 Group:          System Environment/Base
 License:        GPLv3

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -1,7 +1,7 @@
 Summary:	Cmake-3.0.2
 Name:		cmake
 Version:	3.2.1
-Release:	1
+Release:	1%{?dist}
 License:	BSD and LGPLv2+
 URL:		http://www.cmake.org/
 Source0:	http://www.cmake.org/files/v3.2/%{name}-%{version}.tar.gz

--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:	Basic system utilities
 Name:		coreutils
 Version:	8.22
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3
 URL:		http://www.gnu.org/software/coreutils
 Group:		System Environment/Base

--- a/SPECS/cpio/cpio.spec
+++ b/SPECS/cpio/cpio.spec
@@ -1,7 +1,7 @@
 Summary:	cpio-2.11
 Name:		cpio
 Version:	2.11
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/cpio/
 Group:		System Environment/System utilities

--- a/SPECS/cracklib/cracklib.spec
+++ b/SPECS/cracklib/cracklib.spec
@@ -3,7 +3,7 @@
 Summary:	A password strength-checking library.
 Name:		cracklib
 Version:	2.9.2
-Release:	1
+Release:	1%{?dist}
 Group:		System/Libraries
 Source:		cracklib-%{version}.tar.gz
 Source1:    cracklib-words-20080507.gz

--- a/SPECS/createrepo/createrepo.spec
+++ b/SPECS/createrepo/createrepo.spec
@@ -3,7 +3,7 @@
 Summary: 	Creates a common metadata repository
 Name: 		createrepo
 Version: 	0.10.3
-Release: 	1
+Release: 	1%{?dist}
 License:	GPLv2+
 Group: 		System Environment/Base
 Vendor:		VMware, Inc.

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,7 +1,7 @@
 Summary:	An URL retrieval utility and library
 Name:		curl
 Version:	7.41.0
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://curl.haxx.se
 Group:		System Environment/NetworkingLibraries

--- a/SPECS/cyrus-sasl/cyrus-sasl.spec
+++ b/SPECS/cyrus-sasl/cyrus-sasl.spec
@@ -1,7 +1,7 @@
 Summary:	Cyrus Simple Authentication Service Layer (SASL) library
 Name:		cyrus-sasl
 Version:	2.1.26
-Release:	1
+Release:	1%{?dist}
 License:	Custom
 URL:		http://cyrusimap.web.cmu.edu/
 Group:		System Environment/Security

--- a/SPECS/db/db.spec
+++ b/SPECS/db/db.spec
@@ -1,7 +1,7 @@
 Summary:	DB-5.3.28
 Name:		db
 Version:	5.3.28
-Release:	1
+Release:	1%{?dist}
 License:	Sleepycat License
 URL:		https://oss.oracle.com/berkeley-db.html
 Source0:	http://download.oracle.com/berkeley-db/%{name}-%{version}.tar.gz

--- a/SPECS/dbus/dbus.spec
+++ b/SPECS/dbus/dbus.spec
@@ -1,7 +1,7 @@
 Summary:	DBus for systemd
 Name:		dbus
 Version:	1.8.8
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+ or AFL
 URL:		http://www.freedesktop.org/wiki/Software/dbus
 Group:		Applications/File

--- a/SPECS/deltarpm/deltarpm.spec
+++ b/SPECS/deltarpm/deltarpm.spec
@@ -1,7 +1,7 @@
 Summary: Create deltas between rpms
 Name: deltarpm
 Version: 3.6
-Release: 1
+Release: 1%{?dist}
 License: BSD
 Group: Applications/System
 Vendor: VMware, Inc.

--- a/SPECS/diffutils/diffutils.spec
+++ b/SPECS/diffutils/diffutils.spec
@@ -1,7 +1,7 @@
 Summary:	Programs that show the differences between files or directories
 Name:		diffutils
 Version:	3.3
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/diffutils
 Group:		System Environment/Base

--- a/SPECS/docbook-xml/docbook-xml.spec
+++ b/SPECS/docbook-xml/docbook-xml.spec
@@ -1,7 +1,7 @@
 Summary:	Docbook-xml-4.5
 Name:		docbook-xml
 Version:	4.5
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://www.docbook.org
 Source0:	http://www.docbook.org/xml/4.5/%{name}-%{version}.zip

--- a/SPECS/docbook-xsl/docbook-xsl.spec
+++ b/SPECS/docbook-xsl/docbook-xsl.spec
@@ -1,7 +1,7 @@
 Summary:	Docbook-xsl-1.78.1
 Name:		docbook-xsl
 Version:	1.78.1
-Release:	1
+Release:	1%{?dist}
 License:	Apache License
 URL:		http://www.docbook.org
 Source0:	http://downloads.sourceforge.net/docbook/%{name}-%{version}.tar.bz2

--- a/SPECS/docker/docker.spec
+++ b/SPECS/docker/docker.spec
@@ -1,7 +1,7 @@
 Summary:	Docker
 Name:		docker
 Version:	1.6.0
-Release:	2
+Release:	2%{?dist}
 License:	ASL 2.0
 URL:		http://docs.docker.com
 Group:		Applications/File

--- a/SPECS/dparted/dparted.spec
+++ b/SPECS/dparted/dparted.spec
@@ -1,7 +1,7 @@
 Summary:	My summary.
 Name:		dparted
 Version:	0.1
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		dparted-0.1.tar.gz
 Group:		Applications/System

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -5,7 +5,7 @@
 
 Name:		dracut
 Version:	041
-Release:	1
+Release:	1%{?dist}
 Group:		System Environment/Base
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -1,7 +1,7 @@
 Summary:	Contains the utilities for the ext2 file system
 Name:		e2fsprogs
 Version:	1.42.9
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://e2fsprogs.sourceforge.net
 Group:		System Environment/Base

--- a/SPECS/elfutils/elfutils.spec
+++ b/SPECS/elfutils/elfutils.spec
@@ -2,7 +2,7 @@
 Summary:	A collection of utilities and DSOs to handle compiled objects
 Name:		elfutils
 Version:	0.158
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+ and (GPLv2+ or LGPLv3+)
 Group:		Development/Tools
 Source0:	elfutils-%{version}.tar.bz2

--- a/SPECS/etcd/etcd.spec
+++ b/SPECS/etcd/etcd.spec
@@ -1,7 +1,7 @@
 Summary:	Etcd-2.0.4
 Name:		etcd
 Version:	2.0.4
-Release:	1
+Release:	1%{?dist}
 License:	Apache License
 URL:		https://github.com/coreos/etcd
 Group:		System Environment/Security

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -1,7 +1,7 @@
 Summary:	An XML parser library
 Name:		expat
 Version:	2.1.0
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://expat.sourceforge.net/
 Group:		System Environment/GeneralLibraries

--- a/SPECS/file/file.spec
+++ b/SPECS/file/file.spec
@@ -1,7 +1,7 @@
 Summary:	Contains a utility for determining file types
 Name:		file
 Version:	5.22
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://www.darwinsys.com/file
 Group:		Applications/File

--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -1,7 +1,7 @@
 Summary:	Default file system
 Name:		filesystem
 Version:	7.5
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3
 Group:		System Environment/Base
 Vendor:		VMware, Inc.

--- a/SPECS/findutils/findutils.spec
+++ b/SPECS/findutils/findutils.spec
@@ -1,7 +1,7 @@
 Summary:	This package contains programs to find files
 Name:		findutils
 Version:	4.4.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/findutils
 Group:		Applications/File

--- a/SPECS/flex/flex.spec
+++ b/SPECS/flex/flex.spec
@@ -1,7 +1,7 @@
 Summary:	A utility for generating programs that recognize patterns in text
 Name:		flex
 Version:	2.5.38
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://flex.sourceforge.net
 Group:		Applications/System

--- a/SPECS/gawk/gawk.spec
+++ b/SPECS/gawk/gawk.spec
@@ -1,7 +1,7 @@
 Summary:	Contains programs for manipulating text files
 Name:		gawk
 Version:	4.1.0
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3
 URL:		http://www.gnu.org/software/gawk
 Group:		Applications/File

--- a/SPECS/gcc/gcc.spec
+++ b/SPECS/gcc/gcc.spec
@@ -2,7 +2,7 @@
 Summary:	Contains the GNU compiler collection
 Name:		gcc
 Version:	4.8.2
-Release:	2
+Release:	2%{?dist}
 License:	GPLv2+
 URL:		http://gcc.gnu.org
 Group:		Development/Tools

--- a/SPECS/gdb/gdb.spec
+++ b/SPECS/gdb/gdb.spec
@@ -1,7 +1,7 @@
 Summary:	C debugger
 Name:		gdb
 Version:	7.8.2	
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.gnu.org/software/%{name}
 Source0:	http://ftp.gnu.org/gnu/gdb/%{name}-%{version}.tar.gz

--- a/SPECS/gdbm/gdbm.spec
+++ b/SPECS/gdbm/gdbm.spec
@@ -1,7 +1,7 @@
 Summary:	The GNU Database Manager
 Name:		gdbm
 Version:	1.11
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/gdbm
 Group:		Applications/Databases

--- a/SPECS/gettext/gettext.spec
+++ b/SPECS/gettext/gettext.spec
@@ -1,7 +1,7 @@
 Summary:	Utilities for internationalization and localization
 Name:		gettext
 Version:	0.18.3.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3
 URL:		http://www.gnu.org/software/gettext
 Group:		Applications/System

--- a/SPECS/git/git.spec
+++ b/SPECS/git/git.spec
@@ -1,7 +1,7 @@
 Summary:	Fast distributed version control system
 Name:		git
 Version:	2.1.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 URL:		http://git-scm.com/
 Group:		System Environment/Programming

--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -1,7 +1,7 @@
 Summary:	Low-level libraries useful for providing data structure handling for C.
 Name:		glib
 Version:	2.42.0
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 URL:		http://ftp.gnome.org/pub/gnome/sources/glib/2.42/glib-2.42.0.tar.xz
 Group:		Applications/System

--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -3,7 +3,7 @@
 Summary:	Main C library
 Name:		glibc
 Version:	2.21
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 URL:		http://www.gnu.org/software/libc
 Group:		Applications/System

--- a/SPECS/glibmm/glibmm.spec
+++ b/SPECS/glibmm/glibmm.spec
@@ -1,7 +1,7 @@
 Summary:	My summary.
 Name:		glibmm
 Version:	2.42.0
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 URL:		http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.42/glibmm-2.42.0.tar.xz
 Group:		Applications/System

--- a/SPECS/gmp/gmp.spec
+++ b/SPECS/gmp/gmp.spec
@@ -1,7 +1,7 @@
 Summary:	Math libraries
 Name:		gmp
 Version:	5.1.3
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv3+
 URL:		http://www.gnu.org/software/gmp
 Group:		Applications/System

--- a/SPECS/go/go.spec
+++ b/SPECS/go/go.spec
@@ -10,7 +10,7 @@
 Summary:	Go 
 Name:		go
 Version:	1.3.3
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		https://golang/org
 Group:		System Environment/Security

--- a/SPECS/gobject-introspection/gobject-introspection.spec
+++ b/SPECS/gobject-introspection/gobject-introspection.spec
@@ -3,7 +3,7 @@
 Name:       	gobject-introspection
 Summary:    	Introspection system for GObject-based libraries
 Version:    	1.43.3
-Release:    	1
+Release:    	1%{?dist}
 Group:      	Development/Libraries
 License:    	GPLv2+, LGPLv2+, MIT
 URL:        	http://live.gnome.org/GObjectIntrospection

--- a/SPECS/google-daemon/google-daemon.spec
+++ b/SPECS/google-daemon/google-daemon.spec
@@ -1,7 +1,7 @@
 Summary:	Google Daemon
 Name:		google-daemon
 Version:	1.2.2
-Release:	1
+Release:	1%{?dist}
 License:	Apache License
 Group:		System Environment/Base
 URL:		https://github.com/GoogleCloudPlatform/compute-image-packages/

--- a/SPECS/google-startup-scripts/google-startup-scripts.spec
+++ b/SPECS/google-startup-scripts/google-startup-scripts.spec
@@ -1,7 +1,7 @@
 Summary:	Google Startup Scripts
 Name:		google-startup-scripts
 Version:	1.2.2
-Release:	1
+Release:	1%{?dist}
 License:	Apache License
 Group:		System Environment/Base
 URL:		https://github.com/GoogleCloudPlatform/compute-image-packages/

--- a/SPECS/gperf/gperf.spec
+++ b/SPECS/gperf/gperf.spec
@@ -1,7 +1,7 @@
 Summary:	Gperf-3.0.4
 Name:		gperf
 Version:	3.0.4
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://freedesktop.org/wiki/Software/%{name}l/
 Source0:	http://ftp.gnu.org/gnu/gperf/%{name}-%{version}.tar.gz

--- a/SPECS/gpgme/gpgme.spec
+++ b/SPECS/gpgme/gpgme.spec
@@ -1,7 +1,7 @@
 Summary:	High-Level Crypto API
 Name:		gpgme
 Version:	1.5.3
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		https://www.gnupg.org/(it)/related_software/gpgme/index.html
 Group:		Security

--- a/SPECS/gptfdisk/gptfdisk.spec
+++ b/SPECS/gptfdisk/gptfdisk.spec
@@ -1,7 +1,7 @@
 Summary:	gptfdisk-0.8.10
 Name:		gptfdisk
 Version:	0.8.10 
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://sourceforge.net/projects/gptfdisk/
 Group:		System Environment/Filesystem and Disk management

--- a/SPECS/grep/grep.spec
+++ b/SPECS/grep/grep.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for searching through files
 Name:		grep
 Version:	2.21
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/grep
 Group:		Applications/File

--- a/SPECS/groff/groff.spec
+++ b/SPECS/groff/groff.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for processing and formatting text
 Name:		groff
 Version:	1.22.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/groff
 Group:		Applications/Text

--- a/SPECS/grub/grub.spec
+++ b/SPECS/grub/grub.spec
@@ -1,7 +1,7 @@
 Summary:	GRand Unified Bootloader
 Name:		grub
 Version:	2.00
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/grub
 Group:		Applications/System

--- a/SPECS/gtk-doc/gtk-doc.spec
+++ b/SPECS/gtk-doc/gtk-doc.spec
@@ -1,7 +1,7 @@
 Summary:	Program to generate documenation
 Name:		gtk-doc
 Version:	1.21
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.gnu.org/software/%{name}
 Source0:	http://ftp.gnome.org/pub/gnome/sources/gtk-doc/1.21/%{name}-%{version}.tar.xz

--- a/SPECS/gzip/gzip.spec
+++ b/SPECS/gzip/gzip.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for compressing and decompressing files
 Name:		gzip
 Version:	1.6
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software
 Group:		Applications/File

--- a/SPECS/haveged/haveged.spec
+++ b/SPECS/haveged/haveged.spec
@@ -3,7 +3,7 @@
 Summary:        A Linux entropy source using the HAVEGE algorithm
 Name:           haveged
 Version:        1.9.1
-Release:        1.0
+Release:        1.0%{?dist}
 License:        GPLv3+
 Vendor:         VMware, Inc.
 Distribution:   Discus

--- a/SPECS/hawkey/hawkey.spec
+++ b/SPECS/hawkey/hawkey.spec
@@ -1,7 +1,7 @@
 Summary:	Hawkey
 Name:		hawkey
 Version:	2014.1
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 URL:		http://fedoraproject.org/wiki/Features/Hawkey
 Source0:	https://github.com/rpm-software-management/hawkey/archive/%{name}-%{version}.tar.gz

--- a/SPECS/iana-etc/iana-etc.spec
+++ b/SPECS/iana-etc/iana-etc.spec
@@ -1,7 +1,7 @@
 Summary:	Data for network services and protocols
 Name:		iana-etc
 Version:	2.30
-Release:	1
+Release:	1%{?dist}
 License:	OSLv3
 URL:		http://freshmeat.net/projects/iana-etc
 Group:		System Environment/Base

--- a/SPECS/inetutils/inetutils.spec
+++ b/SPECS/inetutils/inetutils.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for basic networking
 Name:		inetutils
 Version:	1.9.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/inetutils
 Group:		Applications/Communications

--- a/SPECS/intltool/intltool.spec
+++ b/SPECS/intltool/intltool.spec
@@ -1,7 +1,7 @@
 Summary:	Intltool-0.50.2 
 Name:		intltool
 Version:	0.50.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://freedesktop.org/wiki/Software/%{name}l/
 Source0:	http://launchpad.net/intltool/trunk/0.50.2/+download/%{name}-%{version}.tar.gz

--- a/SPECS/iproute2/iproute2.spec
+++ b/SPECS/iproute2/iproute2.spec
@@ -1,7 +1,7 @@
 Summary:	Basic and advanced IPV4-based networking
 Name:		iproute2
 Version:	3.12.0
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.kernel.org/pub/linux/utils/net/iproute2
 Group:		Applications/System

--- a/SPECS/iptables/iptables.spec
+++ b/SPECS/iptables/iptables.spec
@@ -1,7 +1,7 @@
 Summary:	Linux kernel packet control tool
 Name:		iptables
 Version:	1.4.21
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.netfilter.org/projects/iptables
 Group:		System Environment/ Security

--- a/SPECS/itstool/itstool.spec
+++ b/SPECS/itstool/itstool.spec
@@ -1,7 +1,7 @@
 Summary:	Itstool-2.0.2
 Name:		itstool
 Version:	2.0.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://itstool.org
 Source0:	http://files.itstool.org/itstool/%{name}-%{version}.tar.bz2

--- a/SPECS/json-glib/json-glib.spec
+++ b/SPECS/json-glib/json-glib.spec
@@ -1,7 +1,7 @@
 Summary:    	Library providing serialization and deserialization support for the JSON format
 Name:       	json-glib
 Version:    	1.0.2
-Release:    	1
+Release:    	1%{?dist}
 License:    	LGPLv2+
 Group:      	Development/Libraries
 Source0:    	http://ftp.gnome.org/pub/GNOME/sources/json-glib/1.0/%{name}-%{version}.tar.xz

--- a/SPECS/kbd/kbd.spec
+++ b/SPECS/kbd/kbd.spec
@@ -1,7 +1,7 @@
 Summary:	Key table files, console fonts, and keyboard utilities
 Name:		kbd
 Version:	2.0.1
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 URL:		http://ftp.altlinux.org/pub/people/legion/kbd
 Group:		Applications/System

--- a/SPECS/kmod/kmod.spec
+++ b/SPECS/kmod/kmod.spec
@@ -1,7 +1,7 @@
 Summary:	Utilities for loading kernel modules
 Name:		kmod
 Version:	16
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.kernel.org/pub/linux/utils/kernel/kmod
 Group:		Applications/System

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -1,7 +1,7 @@
 Summary:	The Kerberos newtork authentication system
 Name:		krb5
 Version:	1.12.2
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://cyrusimap.web.cmu.edu/
 Group:		System Environment/Security

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -4,7 +4,7 @@
 Summary:	Kubernetes cluster management
 Name:		kubernetes
 Version:	0.12.0
-Release:	1
+Release:	1%{?dist}
 License:	ASL 2.0
 URL:		https://github.com/GoogleCloudPlatform/kubernetes
 Source0:	https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.12.0/%{name}.tar.gz

--- a/SPECS/less/less.spec
+++ b/SPECS/less/less.spec
@@ -1,7 +1,7 @@
 Summary:	Text file viewer
 Name:		less
 Version:	458
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.greenwoodsoftware.com/less
 Group:		Applications/File

--- a/SPECS/libaio/libaio.spec
+++ b/SPECS/libaio/libaio.spec
@@ -1,7 +1,7 @@
 Summary:	Linux-native asynchronous I/O access library
 Name:		libaio
 Version:	0.3.110
-Release: 	1
+Release: 	1%{?dist}
 License:	LGPLv2+
 Group:		System Environment/Libraries
 Vendor:		VMware, Inc.

--- a/SPECS/libassuan/libassuan.spec
+++ b/SPECS/libassuan/libassuan.spec
@@ -1,7 +1,7 @@
 Summary:	Provides IPC between GnuPG Components
 Name:		libassuan
 Version:	2.2.0
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		https://www.gnupg.org/(fr)/related_software/libassuan/index.html
 Group:		General Libraries

--- a/SPECS/libcap/libcap.spec
+++ b/SPECS/libcap/libcap.spec
@@ -1,7 +1,7 @@
 Summary:	Libcap-2.24
 Name:		libcap
 Version:	2.24
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		https://www.gnu.org/software/hurd/community/gsoc/project_ideas/libcap.html
 Source0:	https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/%{name}-%{version}.tar.xz

--- a/SPECS/libdnet/libdnet.spec
+++ b/SPECS/libdnet/libdnet.spec
@@ -1,7 +1,7 @@
 Summary:	A simplified, portable interface to several low-level networking routines
 Name:		libdnet
 Version:	1.11
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://prdownloads.sourceforge.net/libdnet/libdnet-1.11.tar.gz
 Group:		Applications/System

--- a/SPECS/libffi/libffi.spec
+++ b/SPECS/libffi/libffi.spec
@@ -1,7 +1,7 @@
 Summary:	A portable, high level programming interface to various calling conventions
 Name:		libffi
 Version:	3.1
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://sourceware.org/libffi/
 Group:		System Environment/GeneralLibraries

--- a/SPECS/libgpg-error/libgpg-error.spec
+++ b/SPECS/libgpg-error/libgpg-error.spec
@@ -2,7 +2,7 @@
 Summary:      	libgpg-error
 Name:         	libgpg-error
 Version:      	1.17
-Release:      	1
+Release:      	1%{?dist}
 License:      	GPLv2+
 URL:          	ftp://ftp.gnupg.org/gcrypt/alpha/libgpg-error/
 Group:		Development/Libraries

--- a/SPECS/libgsystem/libgsystem.spec
+++ b/SPECS/libgsystem/libgsystem.spec
@@ -1,7 +1,7 @@
 Summary:	GIO-based library with Unix/Linux specific API
 Name:		libgsystem
 Version:	2015.1
-Release:	1
+Release:	1%{?dist}
 Group:		Development/Libraries
 Source0:	http://ftp.gnome.org/pub/GNOME/sources/libgsystem/%{version}/%{name}-%{version}.tar.xz
 License:	LGPLv2+

--- a/SPECS/libhif/libhif.spec
+++ b/SPECS/libhif/libhif.spec
@@ -3,7 +3,7 @@
 Summary:   	Simple package manager built on top of hawkey and librepo
 Name:      	libhif
 Version:   	0.1.7
-Release:   	1
+Release:   	1%{?dist}
 License:   	LGPLv2+
 URL:       	https://github.com/hughsie/libhif
 Source0:   	http://people.freedesktop.org/~hughsient/releases/libhif-%{version}.tar.gz

--- a/SPECS/libmspack/libmspack.spec
+++ b/SPECS/libmspack/libmspack.spec
@@ -1,7 +1,7 @@
 Summary:	A library that provides compression and decompression of file formats used by Microsoft
 Name:		libmspack
 Version:	0.4alpha
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 URL:		http://www.cabextract.org.uk/libmspack/libmspack-0.4alpha.tar.gz
 Group:		Applications/System

--- a/SPECS/libpcap/libpcap.spec
+++ b/SPECS/libpcap/libpcap.spec
@@ -1,7 +1,7 @@
 Summary:	C/C++ library for network traffic capture
 Name:		libpcap
 Version:	1.7.2	
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://www.tcpdump.org
 Source0:	http://www.tcpdump.org/release/%{name}-%{version}.tar.gz

--- a/SPECS/libpipeline/libpipeline.spec
+++ b/SPECS/libpipeline/libpipeline.spec
@@ -1,7 +1,7 @@
 Summary:	Library for manipulating pipelines
 Name:		libpipeline
 Version:	1.2.6
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://libpipeline.nongnu.org
 Group:		Applications/System

--- a/SPECS/librepo/librepo.spec
+++ b/SPECS/librepo/librepo.spec
@@ -4,7 +4,7 @@
 Summary:       	Repodata downloading library
 Name:          	librepo
 Version:       	1.17
-Release:       	1
+Release:       	1%{?dist}
 License:       	LGPLv2+
 URL:           	https://github.com/Tojaj/librepo/
 Group:         	System Environment/Libraries

--- a/SPECS/libselinux/libselinux.spec
+++ b/SPECS/libselinux/libselinux.spec
@@ -2,7 +2,7 @@
 Summary:	SELinux library and simple utilities
 Name:		libselinux
 Version:	2.4
-Release:	1
+Release:	1%{?dist}
 License:	Public Domain
 Group:		System Environment/Libraries
 Source0:	https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20150202/%{name}-%{version}.tar.gz

--- a/SPECS/libsepol/libsepol.spec
+++ b/SPECS/libsepol/libsepol.spec
@@ -1,7 +1,7 @@
 Summary:	SELinux binary policy manipulation library 
 Name:		libsepol
 Version:	2.4
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 Group:		System Environment/Libraries
 Source0:	https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20150202/%{name}-%{version}.tar.gz

--- a/SPECS/libsigc++/libsigc++.spec
+++ b/SPECS/libsigc++/libsigc++.spec
@@ -1,7 +1,7 @@
 Summary:	My summary.
 Name:		libsigc++
 Version:	2.4.0
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 URL:		http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.4/libsigc++-2.4.0.tar.xz
 Group:		Applications/System

--- a/SPECS/libsolv/libsolv.spec
+++ b/SPECS/libsolv/libsolv.spec
@@ -1,7 +1,7 @@
 Summary:	Libsolv-0.6.6
 Name:		libsolv
 Version:	0.6.6
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://www.cmake.org/
 Source0:	https://github.com/openSUSE/libsolv/archive/%{name}-%{version}.tar.gz

--- a/SPECS/libtool/libtool.spec
+++ b/SPECS/libtool/libtool.spec
@@ -1,7 +1,7 @@
 Summary:	Shared libraries, portable interface
 Name:		libtool
 Version:	2.4.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 URL:		http://www.gnu.org/software/libtool
 Group:		Development/Tools

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:	Libxml2-2.9.1
 Name:		libxml2
 Version:	2.9.1
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://xmlsoft.org/
 Group:		System Environment/General Libraries

--- a/SPECS/libxslt/libxslt.spec
+++ b/SPECS/libxslt/libxslt.spec
@@ -1,7 +1,7 @@
 Summary:	Libxslt-1.1.28
 Name:		libxslt
 Version:	1.1.28
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http:/http://xmlsoft.org/libxslt/
 Group:		System Environment/General Libraries

--- a/SPECS/libyaml/libyaml.spec
+++ b/SPECS/libyaml/libyaml.spec
@@ -1,7 +1,7 @@
 Summary: Implementation of a YAML 1.1 parser and emitter
 Name: libyaml
 Version: 0.1.6
-Release: 1
+Release: 1%{?dist}
 License: MIT/X Consortium
 Group: Development/Libraries
 URL: http://pyyaml.org/wiki/LibYAML

--- a/SPECS/linux-api-headers/linux-api-headers.spec
+++ b/SPECS/linux-api-headers/linux-api-headers.spec
@@ -1,7 +1,7 @@
 Summary:	Linux API header files
 Name:		linux-api-headers
 Version:	3.19.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 URL:		http://www.kernel.org/
 Group:		System Environment/Kernel

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -1,7 +1,7 @@
 Summary:	Kernel
 Name:		linux
 Version:	3.19.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 URL:		http://www.kernel.org/
 Group:		System Environment/Kernel

--- a/SPECS/lua/lua.spec
+++ b/SPECS/lua/lua.spec
@@ -1,7 +1,7 @@
 Summary:	Programming language
 Name:		lua
 Version:	5.2.3
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://www.lua.org
 Group:		Development/Tools

--- a/SPECS/lvm2/lvm2.spec
+++ b/SPECS/lvm2/lvm2.spec
@@ -1,7 +1,7 @@
 Summary:	Userland logical volume management tools 
 Name:		lvm2
 Version:	2.02.116
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 Group:		System Environment/Base
 URL:		http://sources.redhat.com/dm

--- a/SPECS/lzo/lzo.spec
+++ b/SPECS/lzo/lzo.spec
@@ -1,6 +1,6 @@
 Name:           lzo
 Version:        2.09
-Release:        1
+Release:        1%{?dist}
 Summary:        Data compression library with very fast (de)compression
 Group:          System Environment/Libraries
 License:        GPLv2+

--- a/SPECS/m4/m4.spec
+++ b/SPECS/m4/m4.spec
@@ -1,7 +1,7 @@
 Summary:	A macro processor
 Name:		m4
 Version:	1.4.17
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/m4
 Group:		Development/Tools

--- a/SPECS/make/make.spec
+++ b/SPECS/make/make.spec
@@ -1,7 +1,7 @@
 Summary:	Program for compiling packages
 Name:		make
 Version:	4.0
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/make
 Group:		Development/Tools

--- a/SPECS/man-db/man-db.spec
+++ b/SPECS/man-db/man-db.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for finding and viewing man pages
 Name:		man-db
 Version:	2.6.6
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.nongnu.org/man-db
 Group:		Applications/System

--- a/SPECS/man-pages/man-pages.spec
+++ b/SPECS/man-pages/man-pages.spec
@@ -1,7 +1,7 @@
 Summary:	Man pages
 Name:		man-pages
 Version:	3.59
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+ and BSD
 URL:		http://www.kernel.org/doc/man-pages
 Group:		System Environment/Base

--- a/SPECS/mercurial/mercurial.spec
+++ b/SPECS/mercurial/mercurial.spec
@@ -1,7 +1,7 @@
 Summary:	Mercurial-3.1.2
 Name:		mercurial
 Version:	3.1.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		https://www.ruby-lang.org/en/
 Group:		System Environment/Security

--- a/SPECS/mpc/mpc.spec
+++ b/SPECS/mpc/mpc.spec
@@ -1,7 +1,7 @@
 Summary:	Library for the arithmetic of complex numbers
 Name:		mpc
 Version:	1.0.2
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv3+
 URL:		http://www.multiprecision.org
 Group:		Applications/System

--- a/SPECS/mpfr/mpfr.spec
+++ b/SPECS/mpfr/mpfr.spec
@@ -1,7 +1,7 @@
 Summary:	Functions for multiple precision math
 Name:		mpfr
 Version:	3.1.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.mpfr.org
 Group:		Applications/System

--- a/SPECS/nano/nano.spec
+++ b/SPECS/nano/nano.spec
@@ -1,7 +1,7 @@
 Summary:	Text editor
 Name:		nano
 Version:	2.2.6
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.nano-editor.org/
 Group:		Applications/Editors

--- a/SPECS/ncurses/ncurses.spec
+++ b/SPECS/ncurses/ncurses.spec
@@ -1,7 +1,7 @@
 Summary:	Libraries for terminal handling of character screens
 Name:		ncurses
 Version:	5.9
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://www.gnu.org/software/ncurses
 Group:		Applications/System

--- a/SPECS/nspr/nspr.spec
+++ b/SPECS/nspr/nspr.spec
@@ -1,7 +1,7 @@
 Summary:	Platform-neutral API
 Name:		nspr
 Version:	4.10.3
-Release:	1
+Release:	1%{?dist}
 License:	MPLv2.0
 URL:		http://ftp.mozilla.org/pub/mozilla.org
 Group:		Applications/System

--- a/SPECS/nss/nss.spec
+++ b/SPECS/nss/nss.spec
@@ -1,7 +1,7 @@
 Summary:	Security client
 Name:		nss
 Version:	3.15.4
-Release:	1
+Release:	1%{?dist}
 License:	MPLv2.0
 URL:		http://ftp.mozilla.org/pub/mozilla.org/security/nss
 Group:		Applications/System

--- a/SPECS/ntp/ntp.spec
+++ b/SPECS/ntp/ntp.spec
@@ -1,7 +1,7 @@
 Summary:	Network Time Protocol reference implementation
 Name:		ntp
 Version:	4.2.6p5
-Release:	1
+Release:	1%{?dist}
 License:	NTP
 URL:		http://www.ntp.org/
 Group:		System Environment/NetworkingPrograms

--- a/SPECS/open-vm-tools/open-vm-tools.spec
+++ b/SPECS/open-vm-tools/open-vm-tools.spec
@@ -1,7 +1,7 @@
 Summary:	Usermode tools for VmWare virts
 Name:		open-vm-tools
 Version:	9.10.0
-Release:	2
+Release:	2%{?dist}
 License:	LGPLv2+
 URL:		https://github.com/vmware/open-vm-tools/archive/stable-9.10.x.zip
 Group:		Applications/System

--- a/SPECS/openldap/openldap.spec
+++ b/SPECS/openldap/openldap.spec
@@ -2,7 +2,7 @@
 Summary:	OpenLdap-2.4.40
 Name:		openldap
 Version:	2.4.40
-Release:	1
+Release:	1%{?dist}
 License:	OpenLDAP
 URL:		http://cyrusimap.web.cmu.edu/
 Group:		System Environment/Security

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -1,7 +1,7 @@
 Summary:	'Free version of the SSH connectivity tools
 Name:		openssh
 Version:	6.6p1
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://openssh.org
 Group:		System Environment/Security

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -1,7 +1,7 @@
 Summary:	Management tools and libraries relating to cryptography
 Name:		openssl
 Version:	1.0.2a
-Release:	1
+Release:	1%{?dist}
 License:	OpenSSL
 URL:		http://www.openssl.org
 Group:		System Environment/Security

--- a/SPECS/ostree/ostree.spec
+++ b/SPECS/ostree/ostree.spec
@@ -1,7 +1,7 @@
 Summary:	Git for operating system binaries
 Name:		ostree
 Version:	2015.3
-Release:	1
+Release:	1%{?dist}
 Source0:	http://ftp.gnome.org/pub/GNOME/sources/ostree/%{version}/%{name}-%{version}.tar.xz
 Source1:	91-ostree.preset
 Patch0:		ostree_syntax_error_fix.patch

--- a/SPECS/parted/parted.spec
+++ b/SPECS/parted/parted.spec
@@ -1,7 +1,7 @@
 Summary:	My summary.
 Name:		parted
 Version:	3.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://ftp.gnu.org/gnu/parted/parted-3.2.tar.xz
 Group:		Applications/System

--- a/SPECS/patch/patch.spec
+++ b/SPECS/patch/patch.spec
@@ -1,7 +1,7 @@
 Summary:	Program for modifying or creating files
 Name:		patch
 Version:	2.7.1
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/%{name}
 Source0:	ftp://ftp.gnu.org/gnu/patch/%{name}-%{version}.tar.xz

--- a/SPECS/pcre/pcre.spec
+++ b/SPECS/pcre/pcre.spec
@@ -1,7 +1,7 @@
 Summary:	Grep for perl compatible regular expressions
 Name:		pcre
 Version:	8.36
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.36.tar.gz
 Group:		Applications/System

--- a/SPECS/perl-Config-IniFiles/perl-Config-IniFiles.spec
+++ b/SPECS/perl-Config-IniFiles/perl-Config-IniFiles.spec
@@ -2,7 +2,7 @@
 Summary:        A module for reading .ini-style configuration files
 Name:           perl-Config-IniFiles
 Version:        2.83
-Release:        1
+Release:        1%{?dist}
 Group:          Development/Libraries
 License:        GPL+ or Artistic
 URL:            http://search.cpan.org/dist/Config-IniFiles/

--- a/SPECS/perl-DBD-SQLite/perl-DBD-SQLite.spec
+++ b/SPECS/perl-DBD-SQLite/perl-DBD-SQLite.spec
@@ -2,7 +2,7 @@
 Summary:        SQLite DBI Driver
 Name:           perl-DBD-SQLite
 Version:        1.46
-Release:        1
+Release:        1%{?dist}
 Group:          Development/Libraries
 License:        (GPL+ or Artistic) and Public Domain
 URL:            http://search.cpan.org/dist/DBD-SQLite/

--- a/SPECS/perl-DBI/perl-DBI.spec
+++ b/SPECS/perl-DBI/perl-DBI.spec
@@ -11,7 +11,7 @@
 Summary:        A database access API for perl
 Name:           perl-DBI
 Version:        1.633
-Release:        1
+Release:        1%{?dist}
 Group:          Development/Libraries
 License:        GPL+ or Artistic
 URL:            http://dbi.perl.org/

--- a/SPECS/perl-DBIx-Simple/perl-DBIx-Simple.spec
+++ b/SPECS/perl-DBIx-Simple/perl-DBIx-Simple.spec
@@ -2,7 +2,7 @@
 Summary:        Easy-to-use OO interface to DBI
 Name:           perl-DBIx-Simple
 Version:        1.35
-Release:        1
+Release:        1%{?dist}
 License:        Public Domain
 Group:          Development/Libraries
 Source0:        http://search.cpan.org/CPAN/authors/id/J/JU/JUERD/DBIx-Simple-%{version}.tar.gz 

--- a/SPECS/perl-Exporter-Tiny/perl-Exporter-Tiny.spec
+++ b/SPECS/perl-Exporter-Tiny/perl-Exporter-Tiny.spec
@@ -2,7 +2,7 @@
 Summary:	An exporter with the features of Sub::Exporter but only core dependencies
 Name:		perl-Exporter-Tiny
 Version:	0.042
-Release:	1
+Release:	1%{?dist}
 License:	(GPL+ or Artistic) and Public Domain and (GPL+ or Artistic or CC-BY-SA)
 Group:		Development/Libraries
 URL:		http://search.cpan.org/dist/Exporter-Tiny/

--- a/SPECS/perl-JSON-XS/perl-JSON-XS.spec
+++ b/SPECS/perl-JSON-XS/perl-JSON-XS.spec
@@ -3,7 +3,7 @@ Summary:        JSON serializing/deserializing, done correctly and fast
 Name:           perl-JSON-XS
 Epoch:          1
 Version:        3.01
-Release:        1
+Release:        1%{?dist}
 License:        GPL+ or Artistic
 Group:          Development/Libraries
 URL:            http://search.cpan.org/dist/JSON-XS/

--- a/SPECS/perl-List-MoreUtils/perl-List-MoreUtils.spec
+++ b/SPECS/perl-List-MoreUtils/perl-List-MoreUtils.spec
@@ -2,7 +2,7 @@
 Summary:	Provide the stuff missing in List::Util
 Name:		perl-List-MoreUtils
 Version:	0.410
-Release:	1
+Release:	1%{?dist}
 License:	GPL+ or Artistic
 URL:		http://search.cpan.org/dist/List-MoreUtils/
 Source0:	http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/List-MoreUtils-%{version}.tar.gz

--- a/SPECS/perl-Module-Install/perl-Module-Install.spec
+++ b/SPECS/perl-Module-Install/perl-Module-Install.spec
@@ -5,7 +5,7 @@
 Summary:        Standalone, extensible Perl module installer
 Name:           perl-Module-Install
 Version:        1.14
-Release:        1
+Release:        1%{?dist}
 License:        GPL+ or Artistic
 Group:          Development/Libraries
 URL:            http://search.cpan.org/dist/Module-Install/

--- a/SPECS/perl-Module-ScanDeps/perl-Module-ScanDeps.spec
+++ b/SPECS/perl-Module-ScanDeps/perl-Module-ScanDeps.spec
@@ -2,7 +2,7 @@
 Summary:        Recursively scan Perl code for dependencies
 Name:           perl-Module-ScanDeps
 Version:        1.18
-Release:        1
+Release:        1%{?dist}
 License:        GPL+ or Artistic
 Group:          Development/Libraries
 Source0:        http://search.cpan.org/CPAN/authors/id/R/RS/RSCHUPP/Module-ScanDeps-%{version}.tar.gz 

--- a/SPECS/perl-Types-Serialiser/perl-Types-Serialiser.spec
+++ b/SPECS/perl-Types-Serialiser/perl-Types-Serialiser.spec
@@ -2,7 +2,7 @@
 Summary:	Simple data types for common serialization formats
 Name:		perl-Types-Serialiser
 Version:	1.0
-Release:	1
+Release:	1%{?dist}
 License:	GPL+ or Artistic
 Group:		Development/Libraries
 URL:		http://search.cpan.org/dist/Types-Serialiser/

--- a/SPECS/perl-WWW-Curl/perl-WWW-Curl.spec
+++ b/SPECS/perl-WWW-Curl/perl-WWW-Curl.spec
@@ -7,7 +7,7 @@
 Summary:        Perl extension interface for libcurl
 Name:           perl-WWW-Curl
 Version:        4.17
-Release:        1
+Release:        1%{?dist}
 License:        MIT
 Group:          Development/Libraries
 URL:            http://search.cpan.org/dist/WWW-Curl/

--- a/SPECS/perl-YAML-Tiny/perl-YAML-Tiny.spec
+++ b/SPECS/perl-YAML-Tiny/perl-YAML-Tiny.spec
@@ -2,7 +2,7 @@
 Summary:        Read/Write YAML files with as little code as possible
 Name:           perl-YAML-Tiny
 Version:        1.66
-Release:        1
+Release:        1%{?dist}
 License:        GPL+ or Artistic
 Group:          Development/Libraries
 URL:            http://search.cpan.org/dist/YAML-Tiny/

--- a/SPECS/perl-YAML/perl-YAML.spec
+++ b/SPECS/perl-YAML/perl-YAML.spec
@@ -2,7 +2,7 @@
 Summary:        YAML Ain't Markup Language (tm)
 Name:           perl-YAML
 Version:        1.14
-Release:        1
+Release:        1%{?dist}
 License:        GPL+ or Artistic
 Group:          Development/Libraries
 URL:            http://search.cpan.org/dist/YAML/

--- a/SPECS/perl-common-sense/perl-common-sense.spec
+++ b/SPECS/perl-common-sense/perl-common-sense.spec
@@ -5,7 +5,7 @@
 Summary:	"Common sense" Perl defaults 
 Name:		perl-common-sense
 Version:	3.73
-Release:	1
+Release:	1%{?dist}
 License:	GPL+ or Artistic
 Group:		Development/Libraries
 URL:		http://search.cpan.org/dist/common-sense

--- a/SPECS/perl-libintl/perl-libintl.spec
+++ b/SPECS/perl-libintl/perl-libintl.spec
@@ -2,7 +2,7 @@
 Summary:	Internationalization library for Perl, compatible with gettext
 Name:		perl-libintl
 Version:	1.23
-Release:	1
+Release:	1%{?dist}
 License:	LGPLv2+
 Group: 		Development/Libraries
 URL: 		http://search.cpan.org/dist/libintl-perl/

--- a/SPECS/perl/perl.spec
+++ b/SPECS/perl/perl.spec
@@ -6,7 +6,7 @@
 Summary:	Practical Extraction and Report Language
 Name:		perl
 Version:	5.18.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv1+
 URL:		http://www.perl.org/
 Group:		Development/Languages

--- a/SPECS/photon-release/photon-release.spec
+++ b/SPECS/photon-release/photon-release.spec
@@ -1,7 +1,7 @@
 Summary:	Photon release files
 Name:		photon-release
 Version:	1.0
-Release:	1
+Release:	1%{?dist}
 License:	Apache License
 Group:		System Environment/Base
 URL:		http://photon.org

--- a/SPECS/pkg-config/pkg-config.spec
+++ b/SPECS/pkg-config/pkg-config.spec
@@ -1,7 +1,7 @@
 Summary:	Build tool
 Name:		pkg-config
 Version:	0.28
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://www.freedesktop.org/wiki/Software/pkg-config
 Group:		Development/Tools

--- a/SPECS/popt/popt.spec
+++ b/SPECS/popt/popt.spec
@@ -1,7 +1,7 @@
 Summary:	Programs to parse command-line options
 Name:		popt
 Version:	1.16
-Release:	1
+Release:	1%{?dist}
 License:	MIT
 URL:		http://rpm5.org/files/popt
 Group:		Applications/System

--- a/SPECS/procps-ng/procps-ng.spec
+++ b/SPECS/procps-ng/procps-ng.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for monitoring processes
 Name:		procps-ng
 Version:	3.3.9
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2
 URL:		http://procps.sourceforge.net/
 Group:		Applications/System

--- a/SPECS/psmisc/psmisc.spec
+++ b/SPECS/psmisc/psmisc.spec
@@ -1,7 +1,7 @@
 Summary:	Displays information about running processes
 Name:		psmisc
 Version:	22.20
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://psmisc.sourceforge.net/
 Group:		Applications/System

--- a/SPECS/pycurl/pycurl.spec
+++ b/SPECS/pycurl/pycurl.spec
@@ -2,7 +2,7 @@
 
 Name:           pycurl
 Version:        7.19.5.1
-Release:	    1
+Release:	    1%{?dist}
 Summary:        A Python interface to libcurl
 Group:          Development/Languages
 License:        LGPLv2+ and an MIT/X

--- a/SPECS/pygobject/pygobject.spec
+++ b/SPECS/pygobject/pygobject.spec
@@ -2,7 +2,7 @@
 
 Name:           pygobject
 Version:        3.10.2
-Release:	1
+Release:	1%{?dist}
 Summary:        Python Bindings for GObject
 Group:          Development/Languages
 License:        LGPLv2+

--- a/SPECS/python-configobj/python-configobj.spec
+++ b/SPECS/python-configobj/python-configobj.spec
@@ -1,6 +1,6 @@
 Name:           python-configobj
 Version:        5.0.6
-Release:        1
+Release:        1%{?dist}
 Summary:        Config file reading, writing and validation
 License:        BSD
 Group:          Development/Languages/Python

--- a/SPECS/python-iniparse/python-iniparse.spec
+++ b/SPECS/python-iniparse/python-iniparse.spec
@@ -2,7 +2,7 @@
 
 Name:           python-iniparse
 Version:        0.4
-Release:        1.0
+Release:        1.0%{?dist}
 Summary:        Python Module for Accessing and Modifying Configuration Data in INI files
 Group:          Development/Libraries
 License:        MIT

--- a/SPECS/python-jsonpatch/python-jsonpatch.spec
+++ b/SPECS/python-jsonpatch/python-jsonpatch.spec
@@ -1,6 +1,6 @@
 Name:           python-jsonpatch
 Version:        1.9
-Release:        1
+Release:        1%{?dist}
 Summary:        Applying JSON Patches in Python
 License:        Modified BSD License
 Group:          Development/Languages/Python

--- a/SPECS/python-jsonpointer/python-jsonpointer.spec
+++ b/SPECS/python-jsonpointer/python-jsonpointer.spec
@@ -1,6 +1,6 @@
 Name:           python-jsonpointer
 Version:        1.7
-Release:        1
+Release:        1%{?dist}
 Summary:        Applying JSON Patches in Python
 License:        Modified BSD License
 Group:          Development/Languages/Python

--- a/SPECS/python-prettytable/python-prettytable.spec
+++ b/SPECS/python-prettytable/python-prettytable.spec
@@ -1,6 +1,6 @@
 Name:           python-prettytable
 Version:        0.7.2
-Release:        1
+Release:        1%{?dist}
 Summary:        Library for displaying tabular data in a visually appealing ASCII format
 License:        BSD-2-Clause
 Group:          Development/Languages/Python

--- a/SPECS/python-requests/python-requests.spec
+++ b/SPECS/python-requests/python-requests.spec
@@ -1,6 +1,6 @@
 Name:           python-requests
 Version:        2.5.1
-Release:        1
+Release:        1%{?dist}
 Url:            http://python-requests.org
 Summary:        Awesome Python HTTP Library That's Actually Usable
 License:        Apache2

--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -1,7 +1,7 @@
 Summary: Download, build, install, upgrade, and uninstall Python packages
 Name: python-setuptools
 Version: 12.4
-Release: 1
+Release: 1%{?dist}
 License: Python or ZPLv2.0
 Group: Development/Languages
 URL: https://pypi.python.org/pypi/setuptools

--- a/SPECS/python-six/python-six.spec
+++ b/SPECS/python-six/python-six.spec
@@ -1,6 +1,6 @@
 Name:           python-six
 Version:        1.9.0
-Release:        1
+Release:        1%{?dist}
 Summary:        Python 2 and 3 compatibility utilities
 License:        MIT
 Group:          Development/Languages/Python

--- a/SPECS/python2/python2.spec
+++ b/SPECS/python2/python2.spec
@@ -1,7 +1,7 @@
 Summary:	A high-level scripting language
 Name:		python2
 Version:	2.7.9
-Release:	1
+Release:	1%{?dist}
 License:	PSF
 URL:		http://www.python.org/
 Group:		System Environment/Programming

--- a/SPECS/readline/readline.spec
+++ b/SPECS/readline/readline.spec
@@ -1,7 +1,7 @@
 Summary:	Command-line editing and history capabilities
 Name:		readline
 Version:	6.3
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html
 Group:		Applications/System

--- a/SPECS/rocket/rocket.spec
+++ b/SPECS/rocket/rocket.spec
@@ -1,7 +1,7 @@
 Summary:        Rocket
 Name:           rocket
 Version:        v0.5.1
-Release:        1
+Release:        1%{?dist}
 License:        ASL 2.0
 URL:            http://rocket.readthedocs.org/en/latest/
 Group:          Applications/File

--- a/SPECS/rpm-ostree-toolbox/rpm-ostree-toolbox.spec
+++ b/SPECS/rpm-ostree-toolbox/rpm-ostree-toolbox.spec
@@ -1,7 +1,7 @@
 Summary: 	Extra tools for rpm-ostree
 Name: 		rpm-ostree-toolbox
 Version: 	2015.3
-Release: 	1.0
+Release: 	1.0%{?dist}
 #VCS: https://github.com/cgwalters/rpm-ostree-toolbox
 # This tarball is generated via "make -C packaging -f Makefile.dist-packaging dist-snapshot"
 # which is really just a wrapper for "git archive".

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,7 +1,7 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
 Version:        2015.3
-Release:        1
+Release:        1%{?dist}
 Source0:        rpm-ostree-%{version}.tar.gz
 License:        LGPLv2+
 URL:            https://github.com/cgwalters/rpm-ostree

--- a/SPECS/rpm/rpm.spec
+++ b/SPECS/rpm/rpm.spec
@@ -1,7 +1,7 @@
 Summary:	Package manager
 Name:		rpm
 Version:	4.11.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 URL:		http://rpm.org
 Group:		Applications/System

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -1,7 +1,7 @@
 Summary:	Ruby
 Name:		ruby
 Version:	2.2.1
-Release:	1
+Release:	1%{?dist}
 License:	BSDL
 URL:		https://www.ruby-lang.org/en/
 Group:		System Environment/Security

--- a/SPECS/sed/sed.spec
+++ b/SPECS/sed/sed.spec
@@ -1,7 +1,7 @@
 Summary:	Stream editor
 Name:		sed
 Version:	4.2.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3
 URL:		http://www.gnu.org/software/sed
 Group:		Applications/Editors

--- a/SPECS/shadow/shadow.spec
+++ b/SPECS/shadow/shadow.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for handling passwords in a secure way
 Name:		shadow
 Version:	4.1.5.1
-Release:	2
+Release:	2%{?dist}
 URL:		http://pkg-shadow.alioth.debian.org/
 License:	BSD
 Group:		Applications/System

--- a/SPECS/sqlite-autoconf/sqlite-autoconf.spec
+++ b/SPECS/sqlite-autoconf/sqlite-autoconf.spec
@@ -1,7 +1,7 @@
 Summary:	A portable, high level programming interface to various calling conventions
 Name:		sqlite-autoconf
 Version:	3080301
-Release:	1
+Release:	1%{?dist}
 License:	Public Domain
 URL:		http://www.sqlite.org
 Group:		System Environment/GeneralLibraries

--- a/SPECS/strace/strace.spec
+++ b/SPECS/strace/strace.spec
@@ -1,7 +1,7 @@
 Summary:	Tracks system calls that are made by a running process
 Name:		strace
 Version:	4.10
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://sourceforge.net/p/strace/code/ci/master/tree/
 Group:		Development/Debuggers

--- a/SPECS/sudo/sudo.spec
+++ b/SPECS/sudo/sudo.spec
@@ -1,7 +1,7 @@
 Summary:	Sudo
 Name:		sudo
 Version:	1.8.11p1
-Release:	3
+Release:	3%{?dist}
 License:	ISC
 URL:		https://www.kernel.org/pub/linux/libs/pam/
 Group:		System Environment/Security

--- a/SPECS/swig/swig.spec
+++ b/SPECS/swig/swig.spec
@@ -1,7 +1,7 @@
 Summary:	Connects C/C++/Objective C to some high-level programming languages
 Name:		swig
 Version:	3.0.5
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+ and BSD
 URL:		http://swig.sourceforge.net/
 Source0:	http://downloads.sourceforge.net/project/swig/swig/swig-%{version}/swig-%{version}.tar.gz

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:	Systemd-216
 Name:		systemd
 Version:	216
-Release:	2
+Release:	2%{?dist}
 License:	LGPLv2+ and GPLv2+ and MIT
 URL:		http://www.freedesktop.org/wiki/Software/systemd/
 Group:		System Environment/Security

--- a/SPECS/tar/tar.spec
+++ b/SPECS/tar/tar.spec
@@ -1,7 +1,7 @@
 Summary:	Archiving program
 Name:		tar
 Version:	1.27.1
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/tar
 Group:		Applications/System

--- a/SPECS/tcpdump/tcpdump.spec
+++ b/SPECS/tcpdump/tcpdump.spec
@@ -1,7 +1,7 @@
 Summary:	Packet Analyzer
 Name:		tcpdump
 Version:	4.7.3	
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://www.tcpdump.org
 Source0:	http://www.tcpdump.org/release/%{name}-%{version}.tar.gz

--- a/SPECS/tcsh/tcsh.spec
+++ b/SPECS/tcsh/tcsh.spec
@@ -2,7 +2,7 @@
 Summary:	An enhanced version of csh, the C shell
 Name:		tcsh
 Version:	6.18.01
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 Group:		System Environment/Shells
 Source:		http://www.sfr-fresh.com/unix/misc/%{name}-%{version}.tar.gz

--- a/SPECS/tdnf/tdnf.spec
+++ b/SPECS/tdnf/tdnf.spec
@@ -8,7 +8,7 @@
 Summary:	dnf/yum equivalent using C libs
 Name:		tdnf
 Version:	1.0
-Release:	1
+Release:	1%{?dist}
 Vendor:		VMware, Inc.
 Distribution:	Photon
 License:	VMware

--- a/SPECS/texinfo/texinfo.spec
+++ b/SPECS/texinfo/texinfo.spec
@@ -1,7 +1,7 @@
 Summary:	Reading, writing, and converting info pages
 Name:		texinfo
 Version:	5.2
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/texinfo/
 Group:		Applications/System

--- a/SPECS/thin-provisioning-tools/thin-provisioning-tools.spec
+++ b/SPECS/thin-provisioning-tools/thin-provisioning-tools.spec
@@ -1,7 +1,7 @@
 Summary: 	Thin provisioning tools
 Name:		thin-provisioning-tools
 Version:	0.4.1
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 Group:		System Environment/Base
 URL:		https://github.com/jthornber/thin-provisioning-tools

--- a/SPECS/tzdata/tzdata.spec
+++ b/SPECS/tzdata/tzdata.spec
@@ -1,7 +1,7 @@
 Summary:	Time zone data
 Name:		tzdata
 Version:	2013i
-Release:	1
+Release:	1%{?dist}
 URL:		http://www.iana.org/time-zones
 License:	Public Domain
 Group:		Applications/System

--- a/SPECS/unzip/unzip.spec
+++ b/SPECS/unzip/unzip.spec
@@ -1,7 +1,7 @@
 Summary:	Unzip-6.0
 Name:		unzip
 Version:	6.0
-Release:	1
+Release:	1%{?dist}
 License:	BSD
 URL:		http://www.gnu.org/software/%{name}
 Source0:	http://downloads.sourceforge.net/infozip/unzip60.tar.gz

--- a/SPECS/urlgrabber/urlgrabber.spec
+++ b/SPECS/urlgrabber/urlgrabber.spec
@@ -3,7 +3,7 @@
 Summary:		A high-level cross-protocol url-grabber
 Name: 			urlgrabber
 Version: 		3.10
-Release: 		1
+Release: 		1%{?dist}
 Source0: 		urlgrabber-%{version}.tar.gz
 License: 		LGPLv2+
 Group: 			Development/Libraries

--- a/SPECS/util-linux/util-linux.spec
+++ b/SPECS/util-linux/util-linux.spec
@@ -1,7 +1,7 @@
 Summary:	Utilities for file systems, consoles, partitions, and messages
 Name:		util-linux
 Version:	2.24.1
-Release:	1
+Release:	1%{?dist}
 URL:		http://www.kernel.org/pub/linux/utils/util-linux
 License:	GPLv2+
 Group:		Applications/System

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 Summary:	Text editor
 Name:		vim
 Version:	7.4
-Release:	1
+Release:	1%{?dist}
 License:	Charityware
 URL:		http://www.vim.org
 Group:		Applications/Editors

--- a/SPECS/wget/wget.spec
+++ b/SPECS/wget/wget.spec
@@ -1,7 +1,7 @@
 Summary:	A network utility to retrieve files from the Web
 Name:		wget
 Version:	1.15
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://www.gnu.org/software/wget/wget.html
 Group:		System Environment/NetworkingPrograms

--- a/SPECS/which/which.spec
+++ b/SPECS/which/which.spec
@@ -1,7 +1,7 @@
 Summary:	Program shows full path of (shell) commands
 Name:		which
 Version:	2.20
-Release:	1
+Release:	1%{?dist}
 License:	GPLv3+
 URL:		http://savannah.gnu.org/projects/which
 Source0:	http://ftp.gnu.org/gnu/which/%{name}-%{version}.tar.gz

--- a/SPECS/xerces-c/xerces-c.spec
+++ b/SPECS/xerces-c/xerces-c.spec
@@ -1,7 +1,7 @@
 Summary:	C++ xml parser.
 Name:		xerces-c
 Version:	3.1.1
-Release:	1
+Release:	1%{?dist}
 License:	Apache License
 URL:		http://www.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.1.tar.gz
 Group:		Applications/System

--- a/SPECS/xml-security-c/xml-security-c.spec
+++ b/SPECS/xml-security-c/xml-security-c.spec
@@ -1,7 +1,7 @@
 Summary:	C++ XML Signature and Encryption library.
 Name:		xml-security-c
 Version:	1.5.1
-Release:	1
+Release:	1%{?dist}
 License:	Apache Software License
 URL:		http://pkgs.fedoraproject.org/repo/pkgs/xml-security-c/xml-security-c-1.5.1.tar.gz/2c47c4ec12e8d6abe967aa5e5e99000c/xml-security-c-1.5.1.tar.gz
 Group:		Applications/System

--- a/SPECS/xz/xz.spec
+++ b/SPECS/xz/xz.spec
@@ -1,7 +1,7 @@
 Summary:	Programs for compressing and decompressing files
 Name:		xz
 Version:	5.0.5
-Release:	1
+Release:	1%{?dist}
 URL:		http://tukaani.org/xz
 License:	GPLv2+ and GPLv3+ and LGPLv2+
 Group:		Applications/File

--- a/SPECS/yum-metadata-parser/yum-metadata-parser.spec
+++ b/SPECS/yum-metadata-parser/yum-metadata-parser.spec
@@ -3,7 +3,7 @@
 Summary: 	A fast metadata parser for yum
 Name:       	yum-metadata-parser
 Version:   	1.1.4
-Release:    	1
+Release:    	1%{?dist}
 Source0:    	%{name}-%{version}.tar.gz
 License:    	GPLv2+
 Group:      	Development/Libraries

--- a/SPECS/yum/yum.spec
+++ b/SPECS/yum/yum.spec
@@ -1,7 +1,7 @@
 Summary:	RPM installer/updater
 Name:		yum
 Version:	3.4.3
-Release:	1
+Release:	1%{?dist}
 License:	GPLv2+
 Group:		System Environment/Base
 Source0:	%{name}-%{version}.tar.gz

--- a/SPECS/zlib/zlib.spec
+++ b/SPECS/zlib/zlib.spec
@@ -1,7 +1,7 @@
 Summary:	Compression and decompression routines
 Name:		zlib
 Version:	1.2.8
-Release:	1
+Release:	1%{?dist}
 URL:		http://www.zlib.net/
 License:	zlib
 Group:		Applications/System

--- a/support/package-builder/Specutils.py
+++ b/support/package-builder/Specutils.py
@@ -92,6 +92,12 @@ class Package(object):
         
         if content.find("%{version}") != -1:
             content = content.replace('%{version}',self.version)
+
+        if content.find("%{?dist}") != -1:
+            content = content.replace('%{?dist}',self.distribution)
+
+        if content.find("%{dist}") != -1:
+            content = content.replace('%{dist}',self.distribution)
         
         return content
     


### PR DESCRIPTION
fix in SpecUtils for dist tag processing.
specs updated using - grep -rl "Release:"  --include "*.spec" | xargs sed -i 's/Release:[[:space:]]*[[:digit:]]/&%{?dist}/'