### PR TITLE
unable to calculate storage space on build iso fix

### DIFF
--- a/support/package-builder/PackageManager.py
+++ b/support/package-builder/PackageManager.py
@@ -95,13 +95,15 @@ class PackageManager(object):
         return True
     
     def calculatePossibleNumWorkerThreads(self):
-        process = subprocess.Popen(["df" ,constants.buildRootPath],shell=True,stdout=subprocess.PIPE)
+        cmd = "df "+constants.buildRootPath
+        process = subprocess.Popen("%s" %cmd,shell=True,stdout=subprocess.PIPE)
         retval = process.wait()
         if retval != 0:
             self.logger.error("Unable to check free space. Unknown error.")
             return False
         output = process.communicate()[0]
         device, size, used, available, percent, mountpoint = output.split("\n")[1].split()
+        self.logger.info("Available space:"+available)
         c =  int(available)/600000
         numChroots=int(c)
         self.logger.info("Possible number of worker threads:"+str(numChroots))

--- a/support/package-builder/PackageManager.py
+++ b/support/package-builder/PackageManager.py
@@ -141,7 +141,7 @@ class PackageManager(object):
         statusEvent=threading.Event()
         numWorkerThreads=self.calculatePossibleNumWorkerThreads()
         if numWorkerThreads > 8:
-            numWorkerThreads = 8
+            numWorkerThreads = 1
         if numWorkerThreads == 0:
             return False
          


### PR DESCRIPTION
Thanks to @dthaluru helping me on a VPS dev box as well as implementing this fix from our discussion on https://github.com/vmware/photon/issues/110

This commit fixes the calculating storage space issue when building an iso on Ubuntu/Debian. 
