### PR TITLE
Adding kickstart support

### DIFF
--- a/installer/BUILD_DVD/isolinux/txt.cfg
+++ b/installer/BUILD_DVD/isolinux/txt.cfg
@@ -4,3 +4,8 @@ label install
 	menu default
 	kernel vmlinuz
 	append initrd=initrd.img root=/dev/ram0 loglevel=3
+
+label quiet
+	menu label ^Quiet Install
+	kernel vmlinuz
+	append initrd=initrd.img root=/dev/ram0 ks=cdrom:/isolinux/sample_ks.cfg loglevel=3

--- a/installer/isoInstaller.py
+++ b/installer/isoInstaller.py
@@ -6,6 +6,12 @@
 
 import curses
 import sys
+import subprocess
+import re
+import requests
+import json
+import time
+import os
 from diskpartitioner import DiskPartitioner
 from packageselector import PackageSelector
 from custompackageselector import CustomPackageSelector
@@ -17,6 +23,48 @@ from license import License
 
 class IsoInstaller(object):
 
+    def get_config(self, path, cd_path):
+        if path.startswith("http"):
+            # Do 3 trials to get the kick start
+            # TODO: make sure the installer run after network is up
+            for x in range(0,3):
+                err_msg = ""
+                try:
+                    response = requests.get(path, timeout=3)
+                    if response.ok:
+                        return json.loads(response.text)
+                    err_msg = response.text
+                except Exception as e:
+                    err_msg = e
+                print >> sys.stderr, "Failed to get the kickstart file at {0}, error msg: {1}".format(path, err_msg)
+                print "Failed to get the kickstart file at {0}, retry in a second".format(path)
+                time.sleep(1)
+
+
+            # Something went wrong
+            print "Failed to get the kickstart file at {0}, exiting the installer, check the logs for more details".format(path)
+            raise Exception(err_msg)
+        else:
+            if path.startswith("cdrom:/"):
+                path = os.path.join(cd_path, path.replace("cdrom:/", "", 1))
+            return (JsonWrapper(path)).read();
+
+    def mount_RPMS_cd(self):
+        # Mount the cd to get the RPMS
+        process = subprocess.Popen(['mkdir', '-p', '/mnt/cdrom'])
+        retval = process.wait()
+
+        # Retry mount the CD
+        for i in range(0,3):
+            process = subprocess.Popen(['mount', '/dev/cdrom', '/mnt/cdrom'])
+            retval = process.wait()
+            if retval == 0:
+                return "/mnt/cdrom"
+            print "Failed to mount the cd, retry in a second"
+            time.sleep(1)
+        print "Failed to mount the cd, exiting the installer, check the logs for more details"
+        raise Exception("Can not mount the cd")
+    
     def __init__(self, stdscreen):
         self.screen = stdscreen
 
@@ -33,13 +81,20 @@ class IsoInstaller(object):
 
         curses.curs_set(0)
 
-        self.install_config = {}
+        self.install_config = {'iso_system': False}
+
+        # Mount the cd for the RPM, tools, and may be the ks
+        cd_path = self.mount_RPMS_cd()
+        
+        # check the kickstart params
+        ks_config = None
+        kernel_params = subprocess.check_output(['cat', '/proc/cmdline'])
+        m = re.match(r".*ks=(\S+)\s*.*\s*", kernel_params)
+        if m != None:
+            ks_config = self.get_config(m.group(1), cd_path)
 
         license_agreement = License(self.maxy, self.maxx)
-
-        self.install_config['iso_system'] = False
         select_disk = SelectDisk(self.maxy, self.maxx, self.install_config)
-
         package_selector = PackageSelector(self.maxy, self.maxx, self.install_config)
         custom_package_selector = CustomPackageSelector(self.maxy, self.maxx, self.install_config)
         hostname_reader = WindowStringReader(self.maxy, self.maxx, 10, 70, False,  'Choose the hostname for your system',
@@ -48,18 +103,20 @@ class IsoInstaller(object):
         root_password_reader = WindowStringReader(self.maxy, self.maxx, 10, 70, True,  'Set up root password',
             'Root password:', 
             2, self.install_config)
-        installer = Installer(self.install_config, self.maxy, self.maxx, True, tools_path=None, rpm_path='cdrom', log_path="/var/log")
+        installer = Installer(self.install_config, self.maxy, self.maxx, True, tools_path=cd_path, rpm_path=os.path.join(cd_path, "RPMS"), log_path="/var/log", ks_config=ks_config)
 
         # This represents the installer screen, the bool indicated if I can go back to this window or not
-        items = [
+        items = []
+        if not ks_config:
+            items = items + [
                     (license_agreement.display, False),
                     (select_disk.display, True),
                     (package_selector.display, True),
                     (custom_package_selector.display, False),
                     (hostname_reader.get_user_string, True),
                     (root_password_reader.get_user_string, True),
-                    (installer.install, False)
-                ]
+                 ]
+        items = items + [(installer.install, False)]
 
         index = 0
         params = None

--- a/installer/mk-install-iso.sh
+++ b/installer/mk-install-iso.sh
@@ -36,12 +36,13 @@ PACKAGE_LIST_FILE=$4
 WORKINGDIR=${BUILDROOT}
 BUILDROOT=${BUILDROOT}/photon-chroot
 
-mkdir ${WORKINGDIR}/isolinux
-cp BUILD_DVD/isolinux/* ${WORKINGDIR}/isolinux/
+cp -r BUILD_DVD/isolinux ${WORKINGDIR}/
+cp sample_ks.cfg ${WORKINGDIR}/isolinux/
 
 find ${BUILDROOT} -name linux-[0-9]*.rpm | head -1 | xargs rpm2cpio | cpio -iv --to-stdout ./boot/vmlinuz* > ${WORKINGDIR}/isolinux/vmlinuz
 
 rm -f ${BUILDROOT}/installer/*.pyc
+rm -rf ${BUILDROOT}/installer/BUILD_DVD
 # replace default package_list with specific one
 cp $PACKAGE_LIST_FILE ${BUILDROOT}/installer/package_list.json
 

--- a/installer/modules/commons.py
+++ b/installer/modules/commons.py
@@ -1,0 +1,12 @@
+import re
+
+PRE_INSTALL = "pre-install"
+POST_INSTALL = "post-install"
+
+def replace_string_in_file(filename,  search_string,  replace_string):
+    with open(filename, "r") as source:
+        lines=source.readlines()
+
+    with open(filename, "w") as destination:
+        for line in lines:
+            destination.write(re.sub(search_string,  replace_string,  line))

--- a/installer/modules/m_packages.py
+++ b/installer/modules/m_packages.py
@@ -1,0 +1,24 @@
+import os
+import commons
+from jsonwrapper import JsonWrapper
+
+install_phase = commons.PRE_INSTALL
+enabled = True
+
+def execute(name, ks_config, config, root):
+
+    if ks_config:
+        package_list = JsonWrapper("package_list.json").read()
+
+        if ks_config['type'] == 'micro':
+            packages = package_list["micro_packages"]
+        elif ks_config['type'] == 'minimal':
+            packages = package_list["minimal_packages"]
+        elif ks_config['type'] == 'full':
+            packages = package_list["minimal_packages"] + package_list["optional_packages"]
+        else:
+            #TODO: error
+            packages = []
+
+        config['type'] = ks_config['type']        
+        config["packages"] = packages

--- a/installer/modules/m_partition.py
+++ b/installer/modules/m_partition.py
@@ -1,0 +1,35 @@
+import os
+import subprocess
+import commons
+
+install_phase = commons.PRE_INSTALL
+enabled = True
+
+def partition_disk(disk):
+    partitions_data = {}
+    partitions_data['disk'] = disk
+    partitions_data['root'] = disk + '2'
+
+    output = open(os.devnull, 'w')
+
+    # Clear the disk
+    process = subprocess.Popen(['sgdisk', '-o', '-g', partitions_data['disk']], stdout = output)
+    retval = process.wait()
+
+    # 1: grub, 2: filesystem
+    process = subprocess.Popen(['sgdisk', '-n', '1::+2M', '-n', '2:', '-p', partitions_data['disk']], stdout = output)
+    retval = process.wait()
+
+    # Add the grub flags
+    process = subprocess.Popen(['sgdisk', '-t1:ef02', partitions_data['disk']], stdout = output)
+    retval = process.wait()
+
+    # format the file system
+    process = subprocess.Popen(['mkfs', '-t', 'ext4', partitions_data['root']], stdout = output)
+    retval = process.wait()
+    return partitions_data
+
+def execute(name, ks_config, config, root):
+
+	if ks_config:
+		config['disk'] = partition_disk(ks_config['disk'])

--- a/installer/modules/m_postinstall.py
+++ b/installer/modules/m_postinstall.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import commons
+
+install_phase = commons.POST_INSTALL
+enabled = True
+
+def execute(name, ks_config, config, root):
+
+    if ks_config and 'postinstall' in ks_config:
+        config['postinstall'] = ks_config['postinstall']
+    if 'postinstall' not in config:
+    	return
+    # run the script in the chroot environment
+    script = config['postinstall']
+
+    script_file = os.path.join(root, 'tmp/postinstall.sh')
+
+    with open(script_file,  'wb') as outfile:
+        outfile.write("\n".join(script))
+
+    os.chmod(script_file, 0700);
+    process = subprocess.Popen(["./mk-run-chroot.sh", '-w', root, "/tmp/postinstall.sh"])
+    process.wait()

--- a/installer/modules/m_updatehostname.py
+++ b/installer/modules/m_updatehostname.py
@@ -1,0 +1,19 @@
+import os
+import commons
+
+install_phase = commons.POST_INSTALL
+enabled = True
+
+def execute(name, ks_config, config, root):
+
+    if ks_config:
+        config["hostname"] = ks_config["hostname"]
+    hostname = config['hostname']
+
+    hostname_file = os.path.join(root, 'etc/hostname')
+    hosts_file = os.path.join(root, 'etc/hosts')
+
+    with open(hostname_file,  'wb') as outfile:
+    	outfile.write(hostname)
+
+    commons.replace_string_in_file(hosts_file, r'127\.0\.0\.1\s+localhost', '127.0.0.1\tlocalhost\n127.0.0.1\t' + hostname)

--- a/installer/modules/m_updaterootpassword.py
+++ b/installer/modules/m_updaterootpassword.py
@@ -1,0 +1,34 @@
+import os
+import commons
+import crypt
+import random
+import string
+
+install_phase = commons.POST_INSTALL
+enabled = True
+
+def execute(name, ks_config, config, root):
+
+    if ks_config:
+        # crypt the password if needed
+        if ks_config['password']['crypted']:
+            config['password'] = ks_config['password']['text']
+        else:
+            config['password'] = crypt.crypt(ks_config['password']['text'], 
+                "$6$" + "".join([random.choice(string.ascii_letters + string.digits) for _ in range(16)]))
+    
+    shadow_password = config['password']
+
+    passwd_filename = os.path.join(root, 'etc/passwd')
+    shadow_filename = os.path.join(root, 'etc/shadow')
+    
+    #replace root blank password in passwd file to point to shadow file
+    commons.replace_string_in_file(passwd_filename,  "root::", "root:x:")
+
+    if os.path.isfile(shadow_filename) == False:
+        with open(shadow_filename, "w") as destination:
+            destination.write("root:"+shadow_password+":")
+    else:
+        #add password hash in shadow file
+        commons.replace_string_in_file(shadow_filename, "root::", "root:"+shadow_password+":")
+

--- a/installer/modules/m_updatesshconfig.py
+++ b/installer/modules/m_updatesshconfig.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+import commons
+
+install_phase = commons.POST_INSTALL
+enabled = True
+
+def execute(name, ks_config, config, root):
+    if ks_config and 'public_key' in ks_config:
+        config['public_key'] = ks_config['public_key']
+    if 'public_key' not in config:
+        return
+
+    authorized_keys_dir = os.path.join(root, "root/.ssh")
+    authorized_keys_filename = os.path.join(authorized_keys_dir, "authorized_keys")
+    sshd_config_filename = os.path.join(root, "etc/ssh/sshd_config")
+
+    # Adding the authorized keys
+    if not os.path.exists(authorized_keys_dir):
+        os.makedirs(authorized_keys_dir)
+    with open(authorized_keys_filename, "a") as destination:
+        destination.write(config['public_key'] + "\n")
+    os.chmod(authorized_keys_filename, 0600)
+
+    # Change the sshd config to allow root login
+    process = subprocess.Popen(["sed", "-i", "s/^\\s*PermitRootLogin\s\+no/PermitRootLogin yes/", sshd_config_filename])
+    return process.wait()

--- a/installer/package_list.json
+++ b/installer/package_list.json
@@ -11,7 +11,7 @@
                 "linux", "patch", "cpio",
                 "Linux-PAM", "attr", "libcap", "systemd", "dbus",
                 "elfutils-libelf", "elfutils-libelf-devel", "sqlite-autoconf", "nspr", "nss-devel", "nss", "popt", "lua", "rpm",
-                "which", "gptfdisk", "tar", "gzip", "python2", "python2-devel", "python2-libs", "python2-tools",
+                "which", "gptfdisk", "tar", "gzip", "openssl", "python2", "python2-devel", "python2-libs", "python2-tools", "python-requests",
                 "pcre", "pcre-devel", "glib", "glib-devel", "parted", "libsigc++", "XML-Parser", "glibmm", "dparted",
                 "libgsystem", "ostree"],
 

--- a/installer/sample_ks.cfg
+++ b/installer/sample_ks.cfg
@@ -1,0 +1,15 @@
+{
+    "hostname": "photon-machine",
+    "password": 
+        {
+            "crypted": false,
+            "text": "VMware123!"
+        },
+    "disk": "/dev/sda",
+    "type": "minimal",
+    "postinstall": [
+                		"#!/bin/sh",
+                    	"echo \"Hello World\" > /etc/postinstall"
+                   ],
+    "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDNBCufEER/6lBwFp+osVc/2wIZZXRRjvQkA4dPXOTcSfJDIcvRoGDWbEREQK95GJ8BGQ3IJUDXzb2uSt9daPU0FiPqoFHh84pX8M6EVMpyVrEW0xRutt5KBshQ3BQ6Cmw8bstSFtNYZeB7RnR8cU5xMlhtwEkoECwQhJsFtDzVEfrjJLKdEzNMaFlGbX/QxmY434JhpDo+BYjTYMns5lsz+AORPpCmG/48UtsmqAWsWhndYgD9GK53ISMw3LOg2ocmiP0yVYIYNmFmAztzD8g3erqmVlI64HOcn8VYlUUienu0nPt1lX5uNEGXn8fTOBvuTVkHKGs/f8yzWETTytzTweurBI6EeQVt0QP0+XI6osCxNMMvnh/Vx/xl+dgv9EK61pgzttzA8IbWLGUQu9mLAmHa17R/xoygaGUDKGdcZk4EAtAY2RbhO+xBW0nwyt4977CJGIz672H/oSQ3HtNSdIZI/fA7mDWbymSiFZgAXNhnm/jCO7ZR2AjZ7hd9sQzX+mVOH9lGMBEbznYyVOK+Fy5rHqPtQfcAYCfuoVRhJHhwq90jPl4bXv1Z++Nw97M7DJ2uXy+OFu+3HOQ2HliOozwkDUeoUV7pBX9W7idRr6Xb1h3DEE7Xa5R4QEhmCLb0Hr5sg4+0IADIgg7wrBgkA+l+c6EqRNKFYOzy3xAQqw== mbassiouny@vmware.com"
+}


### PR DESCRIPTION
* Kickstart support enabled using json configuration file.
* Checked in sample_ks.cfg for reference.
* The ks conf can be served from:
	* file system, or
	* http server, or
	* an attached cd.