### PR TITLE
add photon public key

### DIFF
--- a/SPECS/photon-release/photon-release.spec
+++ b/SPECS/photon-release/photon-release.spec
@@ -1,6 +1,6 @@
 Summary:	Photon release files
 Name:		photon-release
-Version:	1.0
+Version:	1.1
 Release:	1%{?dist}
 License:	Apache License
 Group:		System Environment/Base
@@ -28,12 +28,23 @@ for file in photon*repo ; do
   install -m 644 $file $RPM_BUILD_ROOT/etc/yum.repos.d
 done
 
+install -d -m 755 $RPM_BUILD_ROOT/etc/pki/rpm-gpg
+install -m 644 PHOTON-RPM-GPG-KEY $RPM_BUILD_ROOT/etc/pki/rpm-gpg
+
+%post
+rpm --import /etc/pki/rpm-gpg/PHOTON-RPM-GPG-KEY
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
 %dir /etc/yum.repos.d
+/etc/pki/rpm-gpg/PHOTON-RPM-GPG-KEY
 %config(noreplace) /etc/yum.repos.d/photon-iso.repo
 %config(noreplace) /etc/yum.repos.d/photon.repo
 %config(noreplace) /etc/yum.repos.d/photon-updates.repo
+
+%changelog
+*       Wed Jun 17 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.1
+-       Install photon key


### PR DESCRIPTION
Added spec changes to install public key. Incremented version from 1.0 to 1.1. Note that dev builds might not be signed always but this photon-release (the 1.1 source) will turn on gpgsign on all repos and will require override to install rpms.