### PR TITLE
Set cloud-init log config to write to /var/log/cloud-init.log

### DIFF
--- a/SPECS/cloud-init/cloud-init-log.patch
+++ b/SPECS/cloud-init/cloud-init-log.patch
@@ -1,0 +1,13 @@
+diff -uNr cloud-init-0.7.6-orig/config/cloud.cfg.d/05_logging.cfg cloud-init-0.7.6/config/cloud.cfg.d/05_logging.cfg
+--- cloud-init-0.7.6-orig/config/cloud.cfg.d/05_logging.cfg	2015-06-17 21:27:10.378051186 -0700
++++ cloud-init-0.7.6/config/cloud.cfg.d/05_logging.cfg	2015-06-17 21:28:29.676352327 -0700
+@@ -54,7 +54,8 @@
+ 
+ log_cfgs:
+ # These will be joined into a string that defines the configuration
+- - [ *log_base, *log_syslog ]
++# Suppress log_syslog to allow logging to /var/log/cloud-init.log
++# - [ *log_base, *log_syslog ]
+ # These will be joined into a string that defines the configuration
+  - [ *log_base, *log_file ]
+ # A file path can also be used

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,6 +1,6 @@
 Name:           cloud-init
 Version:        0.7.6
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Cloud instance init scripts
 Group:          System Environment/Base
 License:        GPLv3

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -10,6 +10,7 @@ Source1:        cloud-photon.cfg
 
 Patch0:         photon-distro.patch
 Patch1:         systemd-service.patch
+Patch2:         cloud-init-log.patch
 
 BuildRequires:  python2
 BuildRequires:  python2-libs
@@ -33,6 +34,7 @@ ssh keys and to let the user run various scripts.
 %setup -q -n %{name}-%{version}
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 find systemd -name cloud*.service | xargs sed -i s/StandardOutput=journal+console/StandardOutput=journal/g
 
 %build


### PR DESCRIPTION
Comment out rsyslog logging target to allow log to cloud-init.log file. Fix bz 1406237