### PR TITLE
use apache-maven-{ver}-bin file instead of -src

### DIFF
--- a/SPECS/apache-maven/apache-maven.spec
+++ b/SPECS/apache-maven/apache-maven.spec
@@ -1,20 +1,16 @@
 Summary:	Apache Maven
 Name:		apache-maven
 Version:	3.3.3
-Release:	0
+Release:	1%{?dist}
 License:	Apache
 URL:		http://maven.apache.org
 Group:		Applications/System
 Vendor:		VMware, Inc.
 Distribution: 	Photon
-BuildArch:       noarch
-Source0:	http://apache.mirrors.lucidnetworks.net//maven/source/%{name}-%{version}-src.tar.gz
-Requires: openjdk >= 1.8.0.45
-BuildRequires: openjdk >= 1.8.0.45, apache-ant >= 1.9.4, wget >= 1.15
+Source0:	http://apache.mirrors.pair.com/maven/maven-3/%{version}/binaries/%{name}-%{version}-bin.tar.gz
 
-%define _prefix /opt/apache-maven-3.3.3
-%define _bindir %{_prefix}/bin
-%define _libdir %{_prefix}/lib
+Requires: 	openjdk >= 1.8.0.45
+BuildRequires: 	openjdk >= 1.8.0.45
 
 %description
 The Maven package contains binaries for a build system
@@ -22,37 +18,28 @@ The Maven package contains binaries for a build system
 %prep
 
 %setup -q
-echo "nameserver 127.0.1.1" > /etc/resolv.conf
-echo "search localdomain" >> /etc/resolv.conf
 %build
-MAVEN_DIST_DIR=/opt/apache-maven-3.3.3
-
-export JAVA_HOME=/opt/OpenJDK-1.8.0.45-bin
-export ANT_HOME=/opt/apache-ant-1.9.4
-export PATH=$PATH:$ANT_HOME/bin
-
-ant -Dmaven.home=$MAVEN_DIST_DIR
 
 %install
 
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 
 mkdir -p -m 700 %{buildroot}/opt
+install -d -m 755 %{buildroot}/opt/%{name}
+cp -R %{_builddir}/%{name}-%{version}/* %{buildroot}/opt/%{name}/
 
-cp -r /opt/apache-maven-3.3.3 %{buildroot}/opt
+install -d -m 755 %{buildroot}/etc/profile.d/
+echo 'export MAVEN_HOME=/opt/%{name}' > %{buildroot}/etc/profile.d/%{name}.sh
+echo 'export PATH=$MAVEN_HOME/bin:$PATH' >> %{buildroot}/etc/profile.d/%{name}.sh
+echo 'export MAVEN_OPTS=-Xms256m' >> %{buildroot}/etc/profile.d/%{name}.sh
 
 %files
 %defattr(-,root,root)
-%{_bindir}/*
-%{_libdir}/*
-%{_prefix}/LICENSE
-%{_prefix}/NOTICE
-%{_prefix}/README.txt
-%{_prefix}/boot/plexus-classworlds-2.5.2.jar
-%{_prefix}/conf/logging/simplelogger.properties
-%{_prefix}/conf/settings.xml
-%{_prefix}/conf/toolchains.xml
+/opt/%{name}/*
+/etc/profile.d/%{name}.sh
 
 %changelog
+*	Mon Jun 29 2015 Sarah Choi <sarahc@vmware.com> 3.3.3-1
+-	Update PATH and remove unnecessary files
 *	Fri May 22 2015 Sriram Nambakam <snambakam@vmware.com> 1.9.4
 -	Initial build.	First version

--- a/support/pullsources/sources_list.sha1
+++ b/support/pullsources/sources_list.sha1
@@ -1,6 +1,7 @@
 acl-2.2.52.src.tar.gz - 537dddc0ee7b6aa67960a3de2d36f1e2ff2059d9
 ant-contrib-1.0b3-src.tar.gz - b28d2bf18656b263611187fa9fbb95cec93d47c8
 apache-ant-1.9.4-src.tar.gz - 01fe8219e50765beafc69de8b7886f882dee73ec
+apache-maven-3.3.3-bin.tar.gz - c8f257dce3381d9d8c420168a6df0fa25664337c
 apache-maven-3.3.3-src.tar.gz - 70301d0669bc86cd81b25a05b1daab3c6ca23595
 apr-1.5.2.tar.gz - 2ef2ac9a8de7f97f15ef32cddf1ed7325163d84c
 apr-util-1.5.4.tar.gz - 72cc3ac693b52fb831063d5c0de18723bc8e0095


### PR DESCRIPTION
It requires apache-maven-3.3.3-bin.tar.gz to get the package, but originally *-src.tar.gz file was contained.
I also made minor changes for mesos for later use.