### PR TITLE
Workaround for rpm import db-ver-mismatch bug during VMDK install of …

### DIFF
--- a/SPECS/photon-release/photon-release.spec
+++ b/SPECS/photon-release/photon-release.spec
@@ -33,6 +33,8 @@ install -d -m 755 $RPM_BUILD_ROOT/etc/pki/rpm-gpg
 install -m 644 PHOTON-RPM-GPG-KEY $RPM_BUILD_ROOT/etc/pki/rpm-gpg
 
 %post
+# Remove __db* files to workaround BD version check bug in rpm
+rm -f /var/lib/rpm/__db*
 rpm --import /etc/pki/rpm-gpg/PHOTON-RPM-GPG-KEY
 
 %clean


### PR DESCRIPTION
…photon-release package.

Using a workaround suggested online forums for this widely known issue.