### PR TITLE
Add python3 to full install

### DIFF
--- a/SPECS/python3/cgi3.patch
+++ b/SPECS/python3/cgi3.patch
@@ -1,0 +1,17 @@
+--- a/Lib/cgi.py	2014-06-29 19:05:24.000000000 -0700
++++ b/Lib/cgi.py	2015-02-05 18:03:52.273922307 -0800
+@@ -1,13 +1,5 @@
+-#! /usr/local/bin/python
++#! /usr/bin/python
+ 
+-# NOTE: the above "/usr/local/bin/python" is NOT a mistake.  It is
+-# intentionally NOT "/usr/bin/env python".  On many systems
+-# (e.g. Solaris), /usr/local/bin is not in $PATH as passed to CGI
+-# scripts, and /usr/local/bin is the default directory where Python is
+-# installed, so /usr/bin/env would be unable to find python.  Granted,
+-# binary installations by Linux vendors often install Python in
+-# /usr/bin.  So let those vendors patch cgi.py to match their choice
+-# of installation.
+ 
+ """Support module for CGI (Common Gateway Interface) scripts.
+ 

--- a/SPECS/python3/python3.spec
+++ b/SPECS/python3/python3.spec
@@ -1,0 +1,188 @@
+Summary:	A high-level scripting language
+Name:		python3
+Version:	3.4.3
+Release:	1%{?dist}
+License:	PSF
+URL:		http://www.python.org/
+Group:		System Environment/Programming
+Vendor:		VMware, Inc.
+Distribution:	Photon
+Source0:	https://www.python.org/ftp/python/%{version}/Python-%{version}.tar.xz
+%define sha1 Python=7ca5cd664598bea96eec105aa6453223bb6b4456
+Patch:          cgi3.patch
+BuildRequires:	pkg-config >= 0.28
+BuildRequires:	bzip2-devel
+BuildRequires:	ncurses-devel
+BuildRequires:  openssl-devel
+BuildRequires:  readline-devel
+BuildRequires:  xz-devel
+Requires:	bzip2
+Requires:	ncurses
+Requires:  	openssl
+Requires:  	readline
+Requires:  	xz
+Provides: 	python-sqlite
+Provides: 	python(abi)
+Provides: 	/usr/bin/python
+Provides: 	/bin/python
+
+%description
+The Python 3 package contains a new version of Python development environment.
+Python 3 brings more efficient ways of handling dictionaries, better unicode
+strings support, easier and more intuitive syntax, and removes the deprecated
+code. It is incompatible with Python 2.x releases.
+
+%package libs
+Summary: The libraries for python runtime
+Group: Applications/System
+Requires: python3 = %{version}-%{release}
+BuildRequires:	expat >= 2.1.0
+BuildRequires:	libffi >= 3.0.13
+BuildRequires:	ncurses-devel
+BuildRequires:	sqlite-autoconf
+Requires:	coreutils
+Requires:	expat >= 2.1.0
+Requires:	libffi >= 3.0.13
+Requires:	ncurses
+Requires:	sqlite-autoconf
+
+
+%description libs
+The python interpreter can be embedded into applications wanting to
+use python as an embedded scripting language.  The python-libs package
+provides the libraries needed for python 3 applications.
+
+%package devel
+Summary: The libraries and header files needed for Python development.
+Group: Development/Libraries
+Requires: python3 = %{version}-%{release}
+# Needed here because of the migration of Makefile from -devel to the main
+# package
+Conflicts: python3 < %{version}-%{release}
+
+%description devel
+The Python programming language's interpreter can be extended with
+dynamically loaded extensions and can be embedded in other programs.
+This package contains the header files and libraries needed to do
+these types of tasks.
+
+Install python-devel if you want to develop Python extensions.  The
+python package will also need to be installed.  You'll probably also
+want to install the python-docs package, which contains Python
+documentation.
+
+%package tools
+Summary: A collection of development tools included with Python.
+Group: Development/Tools
+Requires: python3 = %{version}-%{release}
+
+%description tools
+The Python package includes several development tools that are used
+to build python programs.
+
+
+%prep
+%setup -q -n Python-%{version}
+%patch -p1
+
+%build
+export OPT="${CFLAGS}"
+./configure \
+	CFLAGS="%{optflags}" \
+	CXXFLAGS="%{optflags}" \
+	--prefix=%{_prefix} \
+	--bindir=%{_bindir} \
+	--libdir=%{_libdir} \
+	--enable-shared \
+	--with-system-expat \
+	--with-system-ffi \
+	--with-dbmliborder=gdbm:ndbm
+make %{?_smp_mflags}
+
+%install
+[ %{buildroot} != "/"] && rm -rf %{buildroot}/*
+make DESTDIR=%{buildroot} altinstall
+chmod -v 755 %{buildroot}%{_libdir}/libpython3.4m.so.1.0
+%{_fixperms} %{buildroot}/*
+
+# Remove unused stuff
+find %{buildroot}%{_libdir} -name '*.pyc' -delete
+find %{buildroot}%{_libdir} -name '*.pyo' -delete
+
+%check
+make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
+
+%post
+-p /sbin/ldconfig
+# Enable below if using 'make install' instead of 'make altinstall'
+#ln -s %{_bindir}/python3 %{_bindir}/python
+#ln -s %{_bindir}/python3-config %{_bindir}/python-config
+#ln -s %{_libdir}/libpython3.4m.so %{_libdir}/libpython3.4.so
+
+%postun
+-p /sbin/ldconfig
+
+%clean
+rm -rf %{buildroot}/*
+
+%files
+%defattr(-, root, root)
+%doc LICENSE README
+%{_bindir}/pydoc*
+%{_bindir}/pyvenv*
+%{_bindir}/python*
+%{_bindir}/pip*
+%{_bindir}/easy_install-3.4
+%{_mandir}/*/*
+
+%dir %{_libdir}/python3.4
+%dir %{_libdir}/python3.4/site-packages
+
+%{_libdir}/libpython3.so
+%{_libdir}/libpython3.4m.so
+%{_libdir}/libpython3.4m.so.1.0
+%{_libdir}/pkgconfig/python-3.4.pc
+# Enable below if using 'make install' instead of 'make altinstall'
+#%{_libdir}/pkgconfig/python-3.4m.pc
+#%{_libdir}/pkgconfig/python3.pc
+
+%exclude %{_libdir}/python3.4/ctypes/test
+%exclude %{_libdir}/python3.4/distutils/tests
+%exclude %{_libdir}/python3.4/sqlite3/test
+%exclude %{_libdir}/python3.4/idlelib/idle_test
+%exclude %{_libdir}/python3.4/test
+#%exclude %{_libdir}/python3.4/unittest
+%exclude %{_libdir}/python3.4/lib-dynload/_ctypes_test.*.so
+
+%files libs
+%defattr(-,root,root)
+%doc LICENSE README
+%{_libdir}/python3.4
+%exclude %{_libdir}/python3.4/ctypes/test
+%exclude %{_libdir}/python3.4/distutils/tests
+%exclude %{_libdir}/python3.4/sqlite3/test
+%exclude %{_libdir}/python3.4/idlelib/idle_test
+%exclude %{_libdir}/python3.4/test
+#%exclude %{_libdir}/python3.4/unittest
+%exclude %{_libdir}/python3.4/lib-dynload/_ctypes_test.*.so
+
+%files devel
+%defattr(-,root,root)
+/usr/include/*
+%doc Misc/README.valgrind Misc/valgrind-python.supp Misc/gdbinit
+%{_libdir}/python3.4/config-3.4m/*
+%exclude %{_libdir}/python3.4/config-3.4m/python.o
+%{_libdir}/libpython3.so
+%exclude %{_bindir}/2to3*
+%exclude %{_bindir}/idle*
+
+%files tools
+%defattr(-,root,root,755)
+%doc Tools/README
+%{_libdir}/python3.4/lib2to3
+%{_bindir}/2to3*
+%{_bindir}/idle*
+
+%changelog
+*	Wed Jul 1 2015 Vinay Kulkarni <kulkarniv@vmware.com> 3.4.3
+-	Add Python3 package to Photon.

--- a/SPECS/syslog-ng/syslog-ng.spec
+++ b/SPECS/syslog-ng/syslog-ng.spec
@@ -1,7 +1,7 @@
 Summary:	Next generation system logger facilty
 Name:		syslog-ng
 Version:	3.6.2
-Release:	1%{?dist}
+Release:	2%{?dist}
 License:	GPL + LGPL
 URL:		https://www.balabit.com/network-security/syslog-ng/opensource-logging-system
 Group:		System Environment/Daemons
@@ -21,6 +21,13 @@ BuildRequires:	python2-devel
  system logging tool. It is often used to manage log messages and implement
  centralized logging, where the aim is to collect the log messages of several
  devices to a single, central log server.
+
+%package	devel
+Summary:	Header and development files for syslog-ng
+Requires:	%{name} = %{version}
+%description    devel
+ syslog-ng-devel package contains header files, pkfconfig files, and libraries
+ needed to build applications using syslog-ng APIs.
 
 %prep
 %setup -q
@@ -74,9 +81,15 @@ rm -rf %{buildroot}/*
 
 %files
 %defattr(-,root,root)
-#TODO - clean this up. split header files into -devel package
-/etc/*
+/etc/syslog-ng/*.conf
+/etc/systemd/system/syslog-ng.service
 /usr/bin/*
+/usr/lib/libsyslog-ng*
+/usr/sbin/syslog-ng
+/usr/sbin/syslog-ng-ctl
+/usr/share/man/*
+
+%files devel
 /usr/include/syslog-ng/*.h
 /usr/include/syslog-ng/compat/*.h
 /usr/include/syslog-ng/control/*.h
@@ -89,17 +102,15 @@ rm -rf %{buildroot}/*
 /usr/include/syslog-ng/stats/*.h
 /usr/include/syslog-ng/template/*.h
 /usr/include/syslog-ng/transport/*.h
-/usr/lib/libsyslog-ng*
+/usr/lib/syslog-ng/lib*.so
 /usr/lib/pkgconfig/syslog-ng.pc
-/usr/lib/syslog-ng/*.so
-/usr/sbin/syslog-ng
-/usr/sbin/syslog-ng-ctl
 /usr/share/include/scl/*
-/usr/share/man/*
 /usr/share/tools/*
 /usr/share/xsd/*
 
 %changelog
+*	Sat Jul 18 2015 Vinay Kulkarni <kulkarniv@vmware.com> 3.6.2-2
+-	Split headers and unshared libs over to devel package.
 *	Thu Jun 4 2015 Vinay Kulkarni <kulkarniv@vmware.com> 3.6.2-1
 -	Add syslog-ng support to photon.
 

--- a/common/data/packages_full.json
+++ b/common/data/packages_full.json
@@ -23,7 +23,7 @@
                 "libaio","libaio-devel","thin-provisioning-tools","lvm2","lvm2-devel","lvm2-libs","lvm2-python-libs","lzo","lzo-devel","lzo-minilzo","swig",
                 "rpm-devel","pycurl","urlgrabber","yum-metadata-parser","yum", "rocket", "strace", "cracklib-python",
                 "haveged", "haveged-devel", "vim-extra",
-                "postgresql", "openjdk", "apr", "apr-util", "httpd", "openvswitch", "eventlog", "syslog-ng", "zookeeper", "fuse", "fleet",
+                "postgresql", "openjdk", "apr", "apr-util", "httpd", "openvswitch", "eventlog", "syslog-ng", "syslog-ng-devel", "zookeeper", "fuse", "fleet",
                 "nss-altfiles", "apache-maven", "subversion", "mesos", "python3", "python3-libs", "python3-devel", "python3-tools"]
 }
 

--- a/common/data/packages_full.json
+++ b/common/data/packages_full.json
@@ -24,7 +24,7 @@
                 "rpm-devel","pycurl","urlgrabber","yum-metadata-parser","yum", "rocket", "strace", "cracklib-python",
                 "haveged", "haveged-devel", "vim-extra",
                 "postgresql", "openjdk", "apr", "apr-util", "httpd", "openvswitch", "eventlog", "syslog-ng", "zookeeper", "fuse", "fleet",
-                "nss-altfiles", "apache-maven", "subversion", "mesos"]
+                "nss-altfiles", "apache-maven", "subversion", "mesos", "python3", "python3-libs", "python3-devel", "python3-tools"]
 }
 
 


### PR DESCRIPTION
cloud-init needs major changes to work with python3, so adding it to full install only. Replacing python2 in minimal will have to wait will cloud-init catches up, or other alternatives are available.
