### PR TITLE
Fix ctags sha1

### DIFF
--- a/SPECS/ctags/ctags.spec
+++ b/SPECS/ctags/ctags.spec
@@ -5,7 +5,7 @@ Release:        1
 License:        GPL
 URL:            http://ctags.sourceforge.net
 Source:         http://prdownloads.sourceforge.net/ctags/ctags-%{version}.tar.gz
-%define         sha1 ctags=482da1ecd182ab39bbdc09f2f02c9fba8cd20030
+%define sha1 ctags=482da1ecd182ab39bbdc09f2f02c9fba8cd20030
 Group:          Development/Tools
 Buildroot:      %{_tmppath}/%{name}-%{version}-root
 Vendor:         VMware, Inc.

--- a/SPECS/fakeroot-ng/fakeroot-ng.spec
+++ b/SPECS/fakeroot-ng/fakeroot-ng.spec
@@ -5,7 +5,7 @@ Release:      1%{?dist}
 License:      GPLv2+
 URL:          http://fakeroot-ng.lingnu.com/
 Source0:      http://downloads.sourceforge.net/project/fakerootng/fakeroot-ng/%{version}/fakeroot-ng-%{version}.tar.gz
-%define       sha1 fakeroot-ng=288dadbd50ff36a9eb11d4bc14213c6d1beaafaa
+%define sha1 fakeroot-ng=288dadbd50ff36a9eb11d4bc14213c6d1beaafaa
 Group:        System Environment/Base
 BuildRoot:    %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Group:        Development/Tools


### PR DESCRIPTION
Extra spacing in the sha1 checksum line at the spec file caused errors due to strict string parsing.