### PR TITLE
bump to 1.0.2 version of kubernetes

### DIFF
--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -1,16 +1,16 @@
-%global commit		ecca42643b91a7117de8cd385b64e6bafecefd65
+%global commit		e310e619fc1ac4f3238bf5ebe9e7033bf5d47ee2
 %global shortcommit	%(c=%{commit}; echo ${c:0:7})
 
 Summary:	Kubernetes cluster management
 Name:		kubernetes
-Version:	0.12.0
+Version:	1.0.2
 Release:	1%{?dist}
 License:	ASL 2.0
 URL:		https://github.com/GoogleCloudPlatform/kubernetes
-Source0:	https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v0.12.0/%{name}.tar.gz
-%define sha1 kubernetes.tar.gz=10d85777784f901a7476e642e7bab1776a834900
-Source1:	https://github.com/GoogleCloudPlatform/kubernetes/archive/%{commit}/kubernetes-ecca426.tar.gz
-%define sha1 kubernetes-ecca426=20cab37ca8ec5eddc0e530e5ce683ee6e8e5bb58
+Source0:	https://github.com/GoogleCloudPlatform/kubernetes/releases/download/v1.0.2/%{name}.tar.gz
+%define sha1 kubernetes.tar.gz=fb3b57031958b2604d2d7112133f147206803601
+Source1:	https://github.com/GoogleCloudPlatform/kubernetes/archive/%{commit}/kubernetes-e310e61.tar.gz
+%define sha1 kubernetes-e310e61=a77e22b1677450c94f7b5eaf50586bb6adcf7e6d
 Group:		Development/Tools
 Vendor:		VMware, Inc.
 Distribution: 	Photon
@@ -25,7 +25,7 @@ tar xf %{SOURCE1}
 %install
 install -vdm644 %{buildroot}/etc/profile.d
 install -vdm755 tmp
-tar -C tmp/ -xvf server/kubernetes-server-linux-amd64.tar.gz 
+tar -C tmp/ -xvf server/kubernetes-server-linux-amd64.tar.gz
 
 install -m 755 -d %{buildroot}%{_bindir}
 
@@ -54,8 +54,6 @@ install -p -m 644 kubernetes-%{commit}/docs/man/man1/* %{buildroot}%{_mandir}/ma
 # install the place the kubelet defaults to put volumes
 install -d %{buildroot}/var/lib/kubelet
 
-%check
-make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %clean
 rm -rf %{buildroot}/*
 %pre
@@ -81,5 +79,7 @@ getent passwd kube >/dev/null || useradd -r -g kube -d / -s /sbin/nologin \
 %config(noreplace) %{_sysconfdir}/%{name}/kubelet
 %config(noreplace) %{_sysconfdir}/%{name}/scheduler
 %changelog
+*	Mon Aug 3 2015 Tom Scanlan <tscanlan@vmware.com> 1.0.2-1
+-	bump up to latest release
 *	Tue Mar 10 2015 Divya Thaluru <dthaluru@vmware.com> 0.12.1-1
 -	Initial build. First version


### PR DESCRIPTION
I've tested this in a 3 node, single master kube cluster.  seems to be running ok.  upgrade from 0.12.0 up to 1.0.2 requires removing all etcd data before the new kube-apiserver will boot up.