### PR TITLE
Add gnome-common and libgudev pkg

### DIFF
--- a/SPECS/NetworkManager/NetworkManager.spec
+++ b/SPECS/NetworkManager/NetworkManager.spec
@@ -1,7 +1,7 @@
 Summary:	NetworkManager
 Name:		NetworkManager
 Version:	1.0.2
-Release:	2%{?dist}
+Release:	3%{?dist}
 License:	LGPLv2+
 URL:		https://download.gnome.org/sources/NetworkManager/1.0/NetworkManager-1.0.2.tar.xz
 Source0:	https://download.gnome.org/sources/NetworkManager/1.0/%{name}-%{version}.tar.xz
@@ -22,6 +22,7 @@ BuildRequires:	python2
 BuildRequires:	python2-libs
 BuildRequires:	dhcp-client
 BuildRequires:	libsoup-devel
+BuildRequires:	libgudev >= 165
 
 %package devel
 Summary:	Libraries and header files for NetworkManager
@@ -85,6 +86,8 @@ EOF
 %{_libdir}/*.so
 %{_libdir}/pkgconfig/*.pc
 %changelog
+*	Wed Aug 12 2015 Vinay Kulkarni <kulkarniv@vmware.com> 1.0.2-3
+-	Add libgudev dependency.
 *	Thu Jul 23 2015 Divya Thaluru <dthaluru@vmware.com> 1.0.2-2
 -	Building with dhclient.
 *	Tue Jun 23 2015 Divya Thaluru <dthaluru@vmware.com> 1.0.2-1

--- a/SPECS/gnome-common/gnome-common.spec
+++ b/SPECS/gnome-common/gnome-common.spec
@@ -1,0 +1,50 @@
+Summary:        Common development macros for GNOME
+Name:           gnome-common
+Version:        3.14.0
+Release:        1%{?dist}
+License:        GPL
+URL:            https://www.gnome.org/
+Source0:        http://ftp.gnome.org/pub/GNOME/sources/%{name}/%{version}/%{name}-%{version}.tar.xz
+%define sha1 gnome-common=555ac7de25821f243f1838faa4d602da50237303
+Group:          System Environment/Libraries
+Vendor:         VMware, Inc.
+Distribution:   Photon
+
+%description
+This provides Common development macros for GNOME.
+
+%prep
+%setup -q
+./autogen.sh
+
+%build
+./configure \
+        --prefix=%{_prefix}
+make %{?_smp_mflags}
+
+%install
+make DESTDIR=%{buildroot} install
+
+%check
+make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
+
+%post	-p /sbin/ldconfig
+
+%postun	-p /sbin/ldconfig
+
+%files
+%defattr(-,root,root)
+%{_bindir}/gnome-autogen.sh
+%{_bindir}/gnome-doc-common
+/usr/share/aclocal/ax_check_enable_debug.m4
+/usr/share/aclocal/ax_code_coverage.m4
+/usr/share/aclocal/gnome-code-coverage.m4
+/usr/share/aclocal/gnome-common.m4
+/usr/share/aclocal/gnome-compiler-flags.m4
+/usr/share/gnome-common/data/omf.make
+/usr/share/gnome-common/data/xmldocs.make
+
+%changelog
+*       Tue Aug 11 2015 Vinay Kulkarni <kulkarniv@vmware.com> 3.14.0-1
+-       Add gnome-common v3.14.0
+

--- a/SPECS/libgudev/libgudev.spec
+++ b/SPECS/libgudev/libgudev.spec
@@ -1,0 +1,64 @@
+Summary:        A library providing GObject bindings for libudev
+Name:           libgudev
+Version:        230
+Release:        1%{?dist}
+License:        LGPL2.1
+URL:            https://git.gnome.org/browse/libgudev/
+Source0:        https://git.gnome.org/browse/%{name}/snapshot/%{name}-%{version}.tar.xz
+%define sha1 libgudev=2f39afc6a9cde5138140d1b03fa438b8f4f59ca0
+Group:          System Environment/Libraries
+Vendor:         VMware, Inc.
+BuildRequires:  glib >= 2.22.0
+BuildRequires:  glib-devel
+BuildRequires:  gnome-common
+BuildRequires:  gobject-introspection
+BuildRequires:  gtk-doc
+BuildRequires:  pkg-config
+BuildRequires:  systemd
+BuildRequires:  which
+Requires:       systemd
+Provides:       libgudev-1.0.so=0-64
+Distribution:   Photon
+
+%description
+This is libgudev, a library providing GObject bindings for libudev. It
+used to be part of udev, and now is a project on its own.
+
+%prep
+%setup -q
+./autogen.sh
+
+%build
+./configure \
+        --prefix=%{_prefix}
+make %{?_smp_mflags}
+
+%install
+make DESTDIR=%{buildroot} install
+
+%check
+make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
+
+%post	-p /sbin/ldconfig
+
+%postun	-p /sbin/ldconfig
+
+%files
+%defattr(-,root,root)
+%{_includedir}/gudev-1.0/gudev/gudev.h
+%{_includedir}/gudev-1.0/gudev/gudevclient.h
+%{_includedir}/gudev-1.0/gudev/gudevdevice.h
+%{_includedir}/gudev-1.0/gudev/gudevenumerator.h
+%{_includedir}/gudev-1.0/gudev/gudevenums.h
+%{_includedir}/gudev-1.0/gudev/gudevenumtypes.h
+%{_includedir}/gudev-1.0/gudev/gudevtypes.h
+%{_libdir}/libgudev-1.0.la
+%{_libdir}/libgudev-1.0.so
+%{_libdir}/libgudev-1.0.so.0
+%{_libdir}/libgudev-1.0.so.0.2.0
+%{_libdir}/pkgconfig/gudev-1.0.pc
+
+%changelog
+*       Tue Aug 11 2015 Vinay Kulkarni <kulkarniv@vmware.com> 230-1
+-       Add libgudev v230
+

--- a/common/data/packages_extra.json
+++ b/common/data/packages_extra.json
@@ -5,7 +5,7 @@
 		"dbus-glib-devel","libndp-devel","libnl-devel","logrotate","kpartx","autogen-devel","gc-devel",
 		"gnutls-devel","guile-devel","json-c-devel","libestr-devel","libgcrypt-devel","liblogging-devel",
 		"librelp-devel","libtasn1-devel","libunistring-devel","nettle-devel",
-	        "apache-ant","ant-contrib","apache-maven","apache-tomcat","jna",
+	        "apache-ant","ant-contrib","apache-maven","apache-tomcat","jna","gnome-common","libgudev",
 		"dhcp-client","dhcp-server","dhcp-libs","dhcp-devel","initscripts","net-tools",
 	        "jaxws-ri","commons-daemon","runit", "python-pyasn1", "WALinuxAgent", "linux-esx"]
 }


### PR DESCRIPTION
This fixes the missing gudev dependency for NetworkManager that occurred due to the systemd v221 update.
