### PR TITLE
Dump photon installer log to /var/log/installer.log

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -77,7 +77,7 @@ class Installer(object):
             self.window.addstr(0, 0, 'Opps, Installer got interrupted.\n\nPress any key to get to the bash...')
             self.window.content_window().getch()
 
-        modules.commons.dump(modules.commons.LOG_ERROR, modules.commons.LOG_FILE_NAME)        
+        modules.commons.dump(modules.commons.LOG_FILE_NAME)        
         sys.exit(1)
 
     def install(self, params):
@@ -134,6 +134,7 @@ class Installer(object):
 
             retval = process.wait()
 
+        modules.commons.dump("{}/{}".format(self.photon_root, modules.commons.LOG_FILE_NAME))
         process = subprocess.Popen([self.unmount_disk_command, '-w', self.photon_root], stdout=self.output)
         retval = process.wait()
 

--- a/installer/modules/commons.py
+++ b/installer/modules/commons.py
@@ -98,8 +98,8 @@ def log(type, message):
     retval = process.wait()
     return retval
 
-def dump(type, filename):
-    command = "journalctl -p {0} | grep --line-buffered \"{1}\" > {2}".format(LOG_LEVEL_DESC[type], SIGNATURE, filename)
+def dump(filename):
+    command = "journalctl | grep --line-buffered \"{0}\" > {1}".format(SIGNATURE, filename)
     process = subprocess.Popen([command], shell=True)
     retval = process.wait()
     return retval


### PR DESCRIPTION
Dumping for both successful and failed installation.