### PR TITLE
Separate apr-util to apr-util, apr-util-devel, aprutil-ldap, apr-util-

### DIFF
--- a/SPECS/apr-util/apr-util.spec
+++ b/SPECS/apr-util/apr-util.spec
@@ -1,7 +1,7 @@
 Summary:    The Apache Portable Runtime Utility Library
 Name:       apr-util
 Version:    1.5.4
-Release:    3%{?dist}
+Release:    4%{?dist}
 License:    Apache License 2.0
 URL:        https://apr.apache.org/
 Group:      System Environment/Libraries
@@ -12,16 +12,50 @@ Source0:    http://archive.apache.org/dist/apr/%{name}-%{version}.tar.gz
 %define     apuver    1
 
 BuildRequires:   apr
-BuildRequires:   openldap
 BuildRequires:   openssl
 BuildRequires:   openssl-devel
 BuildRequires:   nss-devel
 Requires:   apr
 Requires:   openssl
-Requires:   openldap
-Requires:   postgresql
 %description
 The Apache Portable Runtime Utility Library.
+
+%package devel
+Group: Development/Libraries
+Summary: APR utility library development kit
+
+%description devel
+This package provides the support files which can be used to 
+build applications using the APR utility library.
+
+%package ldap
+Group: Development/Libraries
+Summary: APR utility library LDAP support
+BuildRequires: openldap
+Requires: apr-util
+Requires: openldap
+
+%description ldap
+This package provides the LDAP support for the apr-util.
+
+%package pgsql
+Group: Development/Libraries
+Summary: APR utility library PostgreSQL DBD driver
+BuildRequires: postgresql
+Requires: apr-util
+Requires: postgresql
+
+%description pgsql
+This package provides the PostgreSQL driver for the apr-util DBD (database abstraction) interface.
+
+%package sqlite
+Group: Development/Libraries
+Summary: APR utility library SQLite DBD driver.
+Requires: apr-util
+
+%description sqlite
+This package provides the SQLite driver for the apr-util DBD
+(database abstraction) interface.
 
 %prep
 %setup -q
@@ -50,12 +84,37 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
-%{_libdir}/*
+%{_libdir}/aprutil.exp
+%{_libdir}/libexpat.so.*
+%{_libdir}/libaprutil-%{apuver}.so.*
+%{_libdir}/apr-util-%{apuver}/apr_crypto_nss*
+%{_libdir}/apr-util-%{apuver}/apr_crypto_openssl*
 %exclude %{_libdir}/debug
+
+%files devel
+%defattr(-,root,root)
+%{_libdir}/libaprutil-%{apuver}.*a
+%{_libdir}/libaprutil-%{apuver}.so
+%{_libdir}/libexpat.*a
 %{_bindir}/*
 %{_includedir}/*
+%{_libdir}/pkgconfig/apr-util-%{apuver}.pc
+
+%files ldap
+%defattr(-,root,root,-)
+%{_libdir}/apr-util-%{apuver}/apr_ldap*
+
+%files pgsql
+%defattr(-,root,root,-)
+%{_libdir}/apr-util-%{apuver}/apr_dbd_pgsql*
+
+%files sqlite
+%defattr(-,root,root,-)
+%{_libdir}/apr-util-%{apuver}/apr_dbd_sqlite*
 
 %changelog
+*   Wed Sep 19 2015 Xiaolin Li <xiaolinl@vmware.com> 1.5.4.4
+-   Seperate Separate apr-util to apr-util, apr-util-devel, aprutil-ldap, apr-util-pgsql, and apr-utilsqlite.
 *   Wed Jul 15 2015 Sarah Choi <sarahc@vmware.com> 1.5.4-4
 -   Use apuver(=1) instead of version for mesos 
 *   Mon Jul 13 2015 Alexey Makhalov <amakhalov@vmware.com> 1.5.2-3

--- a/SPECS/httpd/httpd.spec
+++ b/SPECS/httpd/httpd.spec
@@ -14,10 +14,13 @@ BuildRequires: openssl-devel
 BuildRequires: pcre-devel
 BuildRequires: apr
 BuildRequires: apr-util
+BuildRequires: apr-util-devel
+BuildRequires: openldap
 BuildRequires: expat
 Requires:   pcre
 Requires:   apr-util
 Requires:   openssl
+Requires:   openldap
 %description
 The Apache HTTP Server.
 

--- a/SPECS/mesos/mesos.spec
+++ b/SPECS/mesos/mesos.spec
@@ -14,6 +14,7 @@ BuildRequires:	curl
 BuildRequires:	apache-maven >= 3.3.3
 BuildRequires:	apr >= 1.5.2
 BuildRequires:	apr-util >= 1.5.4
+BuildRequires:	apr-util-devel >= 1.5.4
 BuildRequires:	subversion >= 1.8.13
 BuildRequires:	subversion-devel >= 1.8.13
 BuildRequires:	cyrus-sasl >= 2.1.26

--- a/SPECS/subversion/subversion.spec
+++ b/SPECS/subversion/subversion.spec
@@ -13,6 +13,7 @@ Requires:   	apr
 Requires:   	apr-util
 BuildRequires: 	apr
 BuildRequires: 	apr-util
+BuildRequires: 	apr-util-devel
 BuildRequires: 	sqlite-autoconf
 BuildRequires: 	libtool
 BuildRequires: 	expat

--- a/common/data/packages_full.json
+++ b/common/data/packages_full.json
@@ -26,7 +26,8 @@
                 "postgresql", "openjdk", "apr", "apr-util", "httpd", "openvswitch", "eventlog", "syslog-ng", "syslog-ng-devel", "zookeeper", "fuse", "fleet",
                 "nss-altfiles", "apache-maven", "subversion", "mesos", "python3", "python3-libs", "python3-devel", "python3-tools", "fakeroot-ng", "ctags",
                 "libtirpc", "libtirpc-devel", "lsof", "nfs-utils", "cve-check-tool", "flannel", "rpm-build", "dkms", "openssl-perl", "xinetd", "tftp", "tftp-server",
-		"audit","audit-devel","libcap-ng","libcap-ng-devel","tcp_wrappers","tcp_wrappers-devel"]
+                "audit","audit-devel","libcap-ng","libcap-ng-devel","tcp_wrappers","tcp_wrappers-devel", "apr-util-devel", "apr-util-ldap", 
+                "apr-util-pgsql", "apr-util-sqlite"]
 }
 
 


### PR DESCRIPTION
pgsql, and apr-utilsqlite. Separate apr-util to apr-util, apr-util-
devel, aprutil-ldap, apr-util-pgsql, and apr-util-sqlite.
Separate apr-util to apr-util, apr-util-devel, aprutil-ldap, apr-util-
pgsql, and apr-utilsqlite. Separate apr-util to apr-util, apr-util-
devel, aprutil-ldap, apr-util-pgsql, and apr-util-sqlite. This change
removes perl dependency from mesos.