### PR TITLE
Changed some minor photon-build-machine settings to get it back running.

### DIFF
--- a/support/make/makedefs.mk
+++ b/support/make/makedefs.mk
@@ -11,8 +11,8 @@ TAR=/bin/tar
 RPMBUILD=/usr/bin/rpmbuild
 SED=/usr/bin/sed
 SHASUM=/usr/bin/shasum
-PACKER=/usr/local/bin/packer
-VAGRANT=/usr/bin/vagrant
+PACKER=env packer
+VAGRANT=env vagrant
 VAGRANT_BUILD=vagrant
 
 SRCROOT := $(realpath $(SRCROOT))

--- a/support/packer-templates/photon-build-machine.json
+++ b/support/packer-templates/photon-build-machine.json
@@ -9,7 +9,7 @@
       "disk_size": 40960,
       "disk_type_id": 0,
       "guest_os_type": "ubuntu-64",
-      "iso_url": "http://ubuntu.bhs.mirrors.ovh.net/ftp.ubuntu.com/releases/trusty/ubuntu-14.04.2-server-amd64.iso",
+      "iso_url": "http://old-releases.ubuntu.com/releases/14.04.2/ubuntu-14.04.2-server-amd64.iso",
       "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
       "iso_checksum_type": "sha1",
       "ssh_username": "vagrant",


### PR DESCRIPTION
* Modified packer and vagrant tool path to 'env packer' and 'env vagrant' to reflect different install locations.
* Switched iso image download url to old-releases server as ubuntu 14.04.2 was update to 14.04.3 by canonical.