### PR TITLE
update build machine to ubuntu 14.04.3

### DIFF
--- a/support/package-builder/Logger.py
+++ b/support/package-builder/Logger.py
@@ -19,23 +19,19 @@ class Logger(object):
             # add formatter to handler
             fhandler.setFormatter(formatter)
             ch.setFormatter(formatter)
-            
+
             logger.addHandler(ch)
             logger.addHandler(fhandler)
             logger.setLevel(logging.DEBUG)
             logger.info("--------------------------------------------------------------------------")
-            logger.info("Staring Log")
+            logger.info("Starting Log")
             logger.info("--------------------------------------------------------------------------")
         return logger
-        
+
 if __name__ == "__main__":
     #Logger.getLogger("my module")
     t1 =  Logger.getLogger("my module")
     t1.info("test1")
-    t2  = Logger.getLogger("my module")  
+    t2  = Logger.getLogger("my module")
     t2.info("test2")
     t1.info("test3")
-       
-    
-        
-        

--- a/support/packer-templates/photon-build-machine.json
+++ b/support/packer-templates/photon-build-machine.json
@@ -1,67 +1,62 @@
 {
-  "builders": [
-    {
-      "name": "photon-build-machine",
-      "vm_name": "photon-build-machine",
-      "vmdk_name": "photon-build-machine-disk0",
-      "type": "vmware-iso",
-      "headless": true,
-      "disk_size": 40960,
-      "disk_type_id": 0,
-      "guest_os_type": "ubuntu-64",
-      "iso_url": "http://ubuntu.bhs.mirrors.ovh.net/ftp.ubuntu.com/releases/trusty/ubuntu-14.04.2-server-amd64.iso",
-      "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
-      "iso_checksum_type": "sha1",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_wait_timeout": "60m",
-      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-      "http_directory": ".",
-      "tools_upload_flavor": "linux",
-      "boot_command": [
-        "<esc><esc><enter><wait>",
-        "/install/vmlinuz noapic ",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/scripts/ubuntu-preseed.cfg ",
-        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
-        "hostname=photon-build-machine ",
-        "fb=false debconf/frontend=noninteractive ",
-        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
-        "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
-        "initrd=/install/initrd.gz -- <enter>"
-      ]
-    }
-  ],
-  "provisioners": [
-    {
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
-      "script": "scripts/ubuntu-vmware-tools_install.sh"
-    },
-    {
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
-      "script": "scripts/ubuntu-puppet_install.sh"
-    },
-    {
-      "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}}{{if .Sudo}} echo 'vagrant' | sudo -E -S {{end}} puppet apply --verbose --modulepath='{{.ModulePath}}' {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} --detailed-exitcodes {{.ManifestFile}}",
-      "manifest_file": "puppet/manifests/vagrant.pp",
-      "manifest_dir": "puppet/manifests",
-      "module_paths": [
-        "puppet/modules"
-      ]
-    },
-    {
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
-      "script": "scripts/ubuntu-vmware-final_cleanup.sh"
-    }
-  ],
- "post-processors": [
-   {
-     "type": "vagrant",
-     "compression_level": 9,
-     "output": "{{.BuildName}}.box"
-   }
- ]
+  "builders": [{
+    "name": "photon-build-machine",
+    "vm_name": "photon-build-machine",
+    "vmdk_name": "photon-build-machine-disk0",
+    "type": "vmware-iso",
+    "headless": true,
+    "disk_size": 40960,
+    "disk_type_id": 0,
+    "guest_os_type": "ubuntu-64",
+    "iso_url": "http://ubuntu.bhs.mirrors.ovh.net/ftp.ubuntu.com/releases/trusty/ubuntu-14.04.3-server-amd64.iso",
+    "iso_checksum": "0501c446929f713eb162ae2088d8dc8b6426224a",
+    "iso_checksum_type": "sha1",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "60m",
+    "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+    "http_directory": ".",
+    "tools_upload_flavor": "linux",
+    "boot_command": [
+      "<esc><esc><enter><wait>",
+      "/install/vmlinuz noapic ",
+      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/scripts/ubuntu-preseed.cfg ",
+      "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+      "hostname=photon-build-machine ",
+      "fb=false debconf/frontend=noninteractive ",
+      "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+      "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+      "initrd=/install/initrd.gz -- <enter>"
+    ]
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
+    "script": "scripts/ubuntu-vmware-tools_install.sh"
+  }, {
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
+    "script": "scripts/ubuntu-puppet_install.sh"
+  }, {
+    "type": "puppet-masterless",
+    "execute_command": "{{.FacterVars}}{{if .Sudo}} echo 'vagrant' | sudo -E -S {{end}} puppet apply --verbose --modulepath='{{.ModulePath}}' {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} --detailed-exitcodes {{.ManifestFile}}",
+    "manifest_file": "puppet/manifests/vagrant.pp",
+    "manifest_dir": "puppet/manifests",
+    "module_paths": [
+      "puppet/modules"
+    ]
+  }, {
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
+    "script": "scripts/ubuntu-install-docker.sh"
+  }, {
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
+    "script": "scripts/ubuntu-vmware-final_cleanup.sh"
+  }],
+  "post-processors": [{
+    "type": "vagrant",
+    "compression_level": 9,
+    "output": "{{.BuildName}}.box"
+  }]
 }

--- a/support/packer-templates/puppet/modules/photonbuildsetup/manifests/init.pp
+++ b/support/packer-templates/puppet/modules/photonbuildsetup/manifests/init.pp
@@ -19,7 +19,6 @@ class photonbuildsetup {
             'cifs-utils',
             'createrepo',
             'rpm',
-            'git',
             'htop',
             'python-aptdaemon',
             'gdisk',

--- a/support/packer-templates/scripts/ubuntu-install-docker.sh
+++ b/support/packer-templates/scripts/ubuntu-install-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "==> Setting up docker from apt.dockerproject.org"
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' | sudo tee /etc/apt/sources.list.d/docker.list
+sudo apt-get update
+sudo apt-get install -y docker-engine

--- a/support/packer-templates/scripts/ubuntu-preseed.cfg
+++ b/support/packer-templates/scripts/ubuntu-preseed.cfg
@@ -93,7 +93,7 @@ d-i pkgsel/install-language-support boolean false
 # manage the VM, build tools and the kernel headers to compile VMware Tools
 # addons
 
-d-i pkgsel/include string openssh-server build-essential linux-kernel-headers bc
+d-i pkgsel/include string openssh-server build-essential linux-kernel-headers bc git-core unzip
 
 # Boot loader installation
 # ------------------------

--- a/support/packer-templates/scripts/ubuntu-vmware-tools_install.sh
+++ b/support/packer-templates/scripts/ubuntu-vmware-tools_install.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
- 
-sudo mount -o loop ~/linux.iso /media/cdrom
-sudo cp /media/cdrom/VMwareTools*.tar.gz ~/
-tar xfz VMwareTools*.tar.gz
-cd ~/vmware-tools-distrib
-sudo ./vmware-install.pl -d
-sudo umount /media/cdrom
-cd ~
-rm -rf vmware-tools-distrib
-rm -f VMwareTools*.tar.gz
-rm linux.iso
+
+git clone https://github.com/rasa/vmware-tools-patches.git
+cd vmware-tools-patches
+sudo ./download-tools.sh 8.0.2
+sudo ./untar-and-patch.sh
+cd vmware-tools-distrib
+sudo ./vmware-install.pl -f -d --clobber-kernel-modules=pvscsi,vmblock,vmci,vmhgfs,vmmemctl,vmsync,vmxnet,vmxnet3,vsock
+cd "$HOME"
+rm -rf vmware-tools-patches

--- a/support/vagrant/photon-build-machine-init.sh
+++ b/support/vagrant/photon-build-machine-init.sh
@@ -37,4 +37,4 @@ fi
 echo "Cleanup the build..."
 sudo make clean
 echo "Shutting down the photon build machine..."
-sudo shutdown -h now
+# sudo shutdown -h now


### PR DESCRIPTION
I wanted to build a new iso from source and it ended up being a bit of a rabbithole.

This fixes the packer templates for an ubuntu 14.0.4.3 build machine. Some other packages were required for me to be able to do `make photon-vagrant-build`

