### PR TITLE
build: improve sanity_check.sh

### DIFF
--- a/support/sanity_check.sh
+++ b/support/sanity_check.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 
+SCRIPTS_DIR="$(dirname ${0})"
+
 # Sanify check for all json files.
 echo "Sanity check for all json files..."
-for i in `find . -name "*.json" -type f -not -path "*stage*"`; do echo $i; json_pp -t null < $i || break -1 ; done
+while read f; do
+	echo "Checking:${f}"
+	if ! json_pp -t null < "${f}" >& /dev/null; then
+		echo "Please check:${f} for syntax errors"
+		exit 1
+	fi
+done < <(find "${SCRIPTS_DIR}/../" -name "*.json" -type f -not -path "*stage*")
 
 echo "Checking all python code is compilable..."
-for i in `find . -name "*.py" -type f -not -path "*stage*"`; do echo $i; python -m py_compile $i || break -1 ; done
+while read f; do
+	echo "Checking:${f}"
+	if ! python -m py_compile "${f}"; then
+		echo "Please check:${f} for complitation errors"
+		exit 1
+	fi
+done < <(find "${SCRIPTS_DIR}/../" -name "*.py" -type f -not -path "*stage*")


### PR DESCRIPTION
- use full path instead of relative path
- fail on script errors

Signed-off-by: Kiril Nesenko <knesenko@vmware.com>