### PR TITLE
Update the index.html with the right URL for the GCE image

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
 
             <ul>
               <li><a href="https://dl.bintray.com/vmware/photon/ami/1.0TP2/x86_64/photon-1.0TP2.tar.gz" target="_blank">Amazon Web Services</a></li>
-              <li><a href="https://dl.bintray.com/vmware/photon/gce/1.0TP2/x86_64/photon-gce.tar.gz" target="_blank">Google Cloud Engine</a></li>
+              <li><a href="https://dl.bintray.com/vmware/photon/gce/1.0TP2/x86_64/photon-1.0TP2.tar.gz" target="_blank">Google Cloud Engine</a></li>
               <li><a href="https://dl.bintray.com/vmware/photon/azure/1.0TP2/x86_64/photon-1.0TP2.vhd" target="_blank">Microsoft Azure</a></li>
             </ul>
 


### PR DESCRIPTION
To address this issue - https://github.com/vmware/photon/issues/409