### PR TITLE
Add note about not using a TLS served resource

### DIFF
--- a/docs/kickstart.md
+++ b/docs/kickstart.md
@@ -45,7 +45,7 @@ Here is an example:
 
     ks=cdrom:/isolinux/my_ks.cfg
 
-The syntax to serve the config-file to the kernel from an HTTP server takes the following form: 
+The syntax to serve the config-file to the kernel from an HTTP server (NOTE: DO NOT use https:// here) takes the following form: 
 
     ks=http://<server>/<config_file_path>
 


### PR DESCRIPTION
Would it make sense to add a note like this?

I tried using a gist from Github, its raw URL to be specific, but it errored out in the initial phase with:

```
init failed
autofs module verification failed 
```