### PR TITLE
Upgrade ceph-deploy to 1.5.39

### DIFF
--- a/SPECS/ceph-deploy/ceph-deploy-init.patch
+++ b/SPECS/ceph-deploy/ceph-deploy-init.patch
@@ -1,37 +1,39 @@
---- a/ceph_deploy/hosts/__init__.py	2017-01-03 21:38:42.000000000 +0000
-+++ b/ceph_deploy/hosts/__init__.py	2017-03-30 23:27:32.453109790 +0000
-@@ -7,7 +7,7 @@ on the type of distribution/version we a
+--- ceph-deploy-1.5.39/ceph_deploy/hosts/__init__.py    2017-04-28 12:32:51.000000000 -0500
++++ ceph-deploy-1.5.39-patched/ceph_deploy/hosts/__init__.py    2018-05-19 00:18:57.938650317 -0500
+@@ -7,7 +7,7 @@
  import logging
  from ceph_deploy import exc
  from ceph_deploy.util import versions
 -from ceph_deploy.hosts import debian, centos, fedora, suse, remotes, rhel
 +from ceph_deploy.hosts import debian, centos, fedora, suse, remotes, rhel, photon
  from ceph_deploy.connection import get_connection
- 
+
  logger = logging.getLogger()
-@@ -68,7 +68,7 @@ def get(hostname,
+@@ -68,7 +68,7 @@
      module.distro = module.normalized_name
-     module.is_el = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific', 'oracle']
+     module.is_el = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific', 'oracle', 'virtuozzo']
      module.is_rpm = module.normalized_name in ['redhat', 'centos',
--                                               'fedora', 'scientific', 'suse', 'oracle']
-+                                               'fedora', 'scientific', 'suse', 'oracle', 'photon']
+-                                               'fedora', 'scientific', 'suse', 'oracle', 'virtuozzo']
++                                               'fedora', 'scientific', 'suse', 'oracle', 'virtuozzo', 'photon']
      module.is_deb = not module.is_rpm
      module.release = release
      module.codename = codename
-@@ -97,6 +97,7 @@ def _get_distro(distro, fallback=None, u
+@@ -97,7 +97,8 @@
          'redhat': centos,
          'fedora': fedora,
          'suse': suse,
-+        'photon': photon,
+-        'virtuozzo' : centos
++        'virtuozzo' : centos,
++        'photon': photon
          }
- 
+
      if distro == 'redhat' and use_rhceph:
-@@ -115,6 +116,8 @@ def _normalized_distro_name(distro):
-         return 'oracle'
-     elif distro.startswith(('suse', 'opensuse')):
+@@ -118,6 +119,8 @@
          return 'suse'
-+    elif distro.startswith('photon'):
-+        return 'photon'
      elif distro.startswith('centos'):
          return 'centos'
++    elif distro.startswith('photon'):
++        return 'photon'
      elif distro.startswith('linuxmint'):
+         return 'ubuntu'
+     elif distro.startswith('virtuozzo'):

--- a/SPECS/ceph-deploy/ceph-deploy-package-manager.patch
+++ b/SPECS/ceph-deploy/ceph-deploy-package-manager.patch
@@ -1,9 +1,9 @@
---- a/ceph_deploy/util/pkg_managers.py	2017-01-03 21:38:42.000000000 +0000
-+++ b/ceph_deploy/util/pkg_managers.py	2017-03-30 21:06:24.369709803 +0000
-@@ -181,6 +181,13 @@ class Yum(RPMManagerBase):
+--- ceph-deploy-1.5.39/ceph_deploy/util/pkg_managers.py 2016-08-15 07:34:53.000000000 -0500
++++ ceph-deploy-1.5.39-patched/ceph_deploy/util/pkg_managers.py 2018-05-19 00:18:57.940650317 -0500
+@@ -181,6 +181,13 @@
      executable = 'yum'
      name = 'yum'
- 
+
 +class Tdnf(RPMManagerBase):
 +    """
 +    The Tdnf Package manager
@@ -11,6 +11,6 @@
 +
 +    executable = 'tdnf'
 +    name = 'tdnf'
- 
+
  class Apt(PackageManager):
      """

--- a/SPECS/ceph-deploy/ceph-deploy-photon-distro-init.patch
+++ b/SPECS/ceph-deploy/ceph-deploy-photon-distro-init.patch
@@ -1,5 +1,5 @@
---- a/ceph_deploy/hosts/photon/__init__.py	2017-03-30 23:17:33.833686463 +0000
-+++ b/ceph_deploy/hosts/photon/__init__.py	2017-03-30 21:10:40.613127409 +0000
+--- ceph-deploy-1.5.39/ceph_deploy/hosts/photon/__init__.py     2018-05-19 00:37:38.354704247 -0500
++++ ceph-deploy-1.5.39-patched/ceph_deploy/hosts/photon/__init__.py     2018-05-19 00:18:57.939650317 -0500
 @@ -0,0 +1,23 @@
 +from . import mon  # noqa
 +from ceph_deploy.hosts.centos.install import repo_install  # noqa
@@ -23,4 +23,4 @@
 +    return 'systemd'
 +
 +def get_packager(module):
-+        return pkg_managers.Tdnf(module)
++        return pkg_managers.Yum(module)

--- a/SPECS/ceph-deploy/ceph-deploy-photon-distro-install.patch
+++ b/SPECS/ceph-deploy/ceph-deploy-photon-distro-install.patch
@@ -1,14 +1,18 @@
---- a/ceph_deploy/hosts/photon/install.py	2017-03-30 23:17:51.357073655 +0000
-+++ b/ceph_deploy/hosts/photon/install.py	2017-03-30 21:59:36.921406467 +0000
-@@ -0,0 +1,88 @@
+--- ceph-deploy-1.5.39/ceph_deploy/hosts/photon/install.py      2018-05-19 00:37:38.354704247 -0500
++++ ceph-deploy-1.5.39-patched/ceph_deploy/hosts/photon/install.py      2018-05-19 00:18:57.939650317 -0500
+@@ -0,0 +1,33 @@
 +from ceph_deploy.lib import remoto
-+from ceph_deploy.hosts.centos.install import repo_install, mirror_install  # noqa
 +from ceph_deploy.util.paths import gpg
 +from ceph_deploy.hosts.common import map_components
 +
 +
 +NON_SPLIT_PACKAGES = ['ceph-osd', 'ceph-mon', 'ceph-mds']
 +
++def repo_install():
++    pass
++
++def mirror_install():
++    pass
 +
 +def install(distro, version_kind, version, adjust_repos, **kw):
 +    packages = map_components(
@@ -18,72 +22,13 @@
 +    gpgcheck = kw.pop('gpgcheck', 1)
 +
 +    logger = distro.conn.logger
-+    release = distro.release
++    release = 'el7'
 +    machine = distro.machine_type
 +
 +    if version_kind in ['stable', 'testing']:
 +        key = 'release'
 +    else:
 +        key = 'autobuild'
-+
-+    if adjust_repos:
-+        if distro.packager.name == 'yum':
-+            distro.packager.install('yum-plugin-priorities')
-+            # haven't been able to determine necessity of check_obsoletes with DNF
-+            distro.conn.remote_module.enable_yum_priority_obsoletes()
-+            logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
-+
-+        if version_kind in ['stable', 'testing']:
-+            distro.packager.add_repo_gpg_key(gpg.url(key))
-+
-+            if version_kind == 'stable':
-+                url = 'https://download.ceph.com/rpm-{version}/fc{release}/'.format(
-+                    version=version,
-+                    release=release,
-+                    )
-+            elif version_kind == 'testing':
-+                url = 'https://download.ceph.com/rpm-testing/fc{release}'.format(
-+                    release=release,
-+                    )
-+
-+            remoto.process.run(
-+                distro.conn,
-+                [
-+                    'rpm',
-+                    '-Uvh',
-+                    '--replacepkgs',
-+                    '--force',
-+                    '--quiet',
-+                    '{url}noarch/ceph-release-1-0.fc{release}.noarch.rpm'.format(
-+                        url=url,
-+                        release=release,
-+                        ),
-+                ]
-+            )
-+
-+            # set the right priority
-+            logger.warning('ensuring that /etc/yum.repos.d/ceph.repo contains a high priority')
-+            distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
-+            logger.warning('altered ceph.repo priorities to contain: priority=1')
-+
-+        elif version_kind in ['dev', 'dev_commit']:
-+            logger.info('skipping install of ceph-release package')
-+            logger.info('repo file will be created manually')
-+            mirror_install(
-+                distro,
-+                'http://gitbuilder.ceph.com/ceph-rpm-fc{release}-{machine}-basic/{sub}/{version}/'.format(
-+                    release=release.split(".", 1)[0],
-+                    machine=machine,
-+                    sub='ref' if version_kind == 'dev' else 'sha1',
-+                    version=version),
-+                gpg.url(key),
-+                adjust_repos=True,
-+                extra_installs=False,
-+                gpgcheck=gpgcheck,
-+            )
-+
-+        else:
-+            raise Exception('unrecognized version_kind %s' % version_kind)
 +
 +    print packages
 +    distro.packager.install(

--- a/SPECS/ceph-deploy/ceph-deploy-photon-distro-mon-init.patch
+++ b/SPECS/ceph-deploy/ceph-deploy-photon-distro-mon-init.patch
@@ -1,5 +1,5 @@
---- a/ceph_deploy/hosts/photon/mon/__init__.py	2017-03-30 23:18:07.888497582 +0000
-+++ b/ceph_deploy/hosts/photon/mon/__init__.py	2017-03-30 22:44:04.737113094 +0000
+--- ceph-deploy-1.5.39/ceph_deploy/hosts/photon/mon/__init__.py 2018-05-19 00:38:33.724706913 -0500
++++ ceph-deploy-1.5.39-patched/ceph_deploy/hosts/photon/mon/__init__.py 2018-05-19 00:18:57.939650317 -0500
 @@ -0,0 +1,2 @@
 +from ceph_deploy.hosts.common import mon_add as add  # noqa
 +from ceph_deploy.hosts.common import mon_create as create  # noqa

--- a/SPECS/ceph-deploy/ceph-deploy-photon-distro-uninstall.patch
+++ b/SPECS/ceph-deploy/ceph-deploy-photon-distro-uninstall.patch
@@ -1,5 +1,5 @@
---- a/ceph_deploy/hosts/photon/uninstall.py	2017-03-30 23:17:51.357073655 +0000
-+++ b/ceph_deploy/hosts/photon/uninstall.py	2017-03-30 21:39:56.753696000 +0000
+--- ceph-deploy-1.5.39/ceph_deploy/hosts/photon/uninstall.py    2018-05-19 00:37:38.354704247 -0500
++++ ceph-deploy-1.5.39-patched/ceph_deploy/hosts/photon/uninstall.py    2018-05-19 00:18:57.939650317 -0500
 @@ -0,0 +1,8 @@
 +def uninstall(distro, purge=False):
 +    packages = [

--- a/SPECS/ceph-deploy/ceph-deploy-remote.patch
+++ b/SPECS/ceph-deploy/ceph-deploy-remote.patch
@@ -1,15 +1,15 @@
---- a/ceph_deploy/hosts/remotes.py	2017-01-03 21:38:42.000000000 +0000
-+++ b/ceph_deploy/hosts/remotes.py	2017-03-30 21:54:58.410977997 +0000
-@@ -14,6 +14,12 @@ def platform_information(_linux_distribu
+--- ceph-deploy-1.5.39/ceph_deploy/hosts/remotes.py     2017-09-01 06:30:23.000000000 -0500
++++ ceph-deploy-1.5.39-patched/ceph_deploy/hosts/remotes.py     2018-05-19 00:18:57.939650317 -0500
+@@ -14,6 +14,12 @@
      """ detect platform information from remote host """
      linux_distribution = _linux_distribution or platform.linux_distribution
      distro, release, codename = linux_distribution()
++
 +    if 'photon' in distro.lower():
 +        distro = 'photon'
-+        release = '1.0'
++        release = '2.0'
 +        codename = 'photon'
-+
 +
      if not codename and 'debian' in distro.lower():  # this could be an empty string in Debian
          debian_codenames = {
-             '8': 'jessie',
+             '10': 'buster',

--- a/SPECS/ceph-deploy/ceph-deploy.spec
+++ b/SPECS/ceph-deploy/ceph-deploy.spec
@@ -1,7 +1,7 @@
 %{!?python2_sitelib: %global python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 
 Name:           ceph-deploy
-Version:        1.5.37
+Version:        1.5.39
 Release:        3%{?dist}
 Url:            http://ceph.com/
 Summary:        Admin and deploy tool for Ceph
@@ -9,7 +9,7 @@ License:        MIT
 Group:          System/Filesystems
 Vendor:         VMware, Inc.
 Distribution:   Photon
-Source0:        https://pypi.python.org/packages/23/f0/f144b1b55534a3e10d269dbfbe092e0aaa1c4b826c24f5df9320ae9bdfce/%{name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/63/59/c2752952b7867faa2d63ba47c47da96e2f43f5124029975b579020df3665/%{name}-%{version}.tar.gz
 %define sha1 ceph-deploy=5c19b318320f2729c5b15da7159aa9824b885c1a
 Patch0:		ceph-deploy-init.patch
 Patch1:		ceph-deploy-package-manager.patch
@@ -58,6 +58,8 @@ install -m 0755 -D scripts/ceph-deploy $RPM_BUILD_ROOT/usr/bin
 %{_bindir}/ceph-deploy
 
 %changelog
+*   Fri May 18 2018 Grant Curell <grant.curell@salientcrgt.com> 1.5.39
+-   Upgrading to version 1.5.39
 *   Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.5.37-3
 -   Use python2 explicitly
 *   Tue Apr 25 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.5.37-2


### PR DESCRIPTION
- Update ceph-deploy to v1.5.39
- Removes code from the installer which adds ceph repos. Because we aren't using ceph's packages, when the repos are present, ceph-deploy attempts to pull incorrect packages from ceph repos instead of VMWare Photon repos.
- Removes imports from centos since they are not needed
- Changes the installer to yum. It may work with tdnf, but in current state is broken.