### PR TITLE
pax, plugins: gcc8 - compile fix

### DIFF
--- a/SPECS/linux/0001-NOWRITEEXEC-and-PAX-features-MPROTECT-EMUTRAMP.patch
+++ b/SPECS/linux/0001-NOWRITEEXEC-and-PAX-features-MPROTECT-EMUTRAMP.patch
@@ -61,9 +61,9 @@ index 045338a..778820a 100644
 +	if (v8086_mode(regs))
 +		ip = ((regs->cs & 0xffff) << 4) + (ip & 0xffff);
 +
-+	if ((__supported_pte_mask & _PAGE_NX) && (error_code & PF_INSTR))
++	if ((__supported_pte_mask & _PAGE_NX) && (error_code & X86_PF_INSTR))
 +		return true;
-+	if (!(error_code & (PF_PROT | PF_WRITE)) && ip == address)
++	if (!(error_code & (X86_PF_PROT | X86_PF_WRITE)) && ip == address)
 +		return true;
 +	return false;
 +}

--- a/SPECS/linux/0003-Added-rap_plugin.patch
+++ b/SPECS/linux/0003-Added-rap_plugin.patch
@@ -5872,7 +5872,7 @@ index 000000000000..2f53f142a1e2
 +	cond_bb = e->src;
 +	join_bb = e->dest;
 +	e->flags = EDGE_FALSE_VALUE;
-+	e->probability = REG_BR_PROB_BASE;
++//	e->probability = REG_BR_PROB_BASE;
 +
 +	true_bb = create_empty_bb(EXIT_BLOCK_PTR_FOR_FN(cfun)->prev_bb);
 +	make_edge(cond_bb, true_bb, EDGE_TRUE_VALUE | EDGE_PRESERVE);


### PR DESCRIPTION
Use the solution provided in [c3606ec](https://github.com/jameshilliard/linux-grsec/blob/4.4.162-grsec/scripts/gcc-plugins/rap_plugin/rap_fptr_pass.c) to correct this error:

  HOSTCXX -fPIC scripts/gcc-plugins/rap_plugin/sip.o
In file included from /usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/basic-block.h:23,
                 from /usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/backend.h:32,
                 from /usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/gcc-plugin.h:30,
                 from scripts/gcc-plugins/gcc-common.h:7,
                 from scripts/gcc-plugins/rap_plugin/rap.h:4,
                 from scripts/gcc-plugins/rap_plugin/rap_fptr_pass.c:8:
scripts/gcc-plugins/rap_plugin/rap_fptr_pass.c: In function ‘basic_block_def* rap_instrument_fptr(gimple_stmt_iterator*)’:
/usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/profile-count.h:63:27: error: no match for ‘operator=’ (operand types are ‘profile_probability’ and ‘int’)
 #define REG_BR_PROB_BASE  10000
                           ^~~~~
scripts/gcc-plugins/rap_plugin/rap_fptr_pass.c:112:19: note: in expansion of macro ‘REG_BR_PROB_BASE’
  e->probability = REG_BR_PROB_BASE;
                   ^~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/profile-count.h:136:19: note: candidate: ‘profile_probability& profile_probability::operator=(const profile_probability&)’
 class GTY((user)) profile_probability
                   ^~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/profile-count.h:136:19: note:   no known conversion for argument 1 from ‘int’ to ‘const profile_probability&’
make[2]: *** [scripts/Makefile.host:141: scripts/gcc-plugins/rap_plugin/rap_fptr_pass.o] Error 1