### PR TITLE
Remove reference to iostat

### DIFF
--- a/docs/photon_troubleshoot/linux-troubleshooting-tools.md
+++ b/docs/photon_troubleshoot/linux-troubleshooting-tools.md
@@ -2,7 +2,6 @@
 
 The following Linux troubleshoot tools are neither installed on Photon OS by default nor available in the Photon OS repositories: 
 
-* iostat
 * telnet (use SSH instead)
 * Iprm
 * hdparm


### PR DESCRIPTION
This document incorrectly states that iostat is not available in Photon OS repositories. However, this package *is* available -- it is installed when the sysstat package is installed (see other packages sysstat includes here: https://github.com/sysstat/sysstat). I confirmed this on the latest build of Photon OS.