### PR TITLE
Simple photon platform fixes

### DIFF
--- a/SPECS/photon-release/photon-release.spec
+++ b/SPECS/photon-release/photon-release.spec
@@ -1,13 +1,17 @@
 Summary:    Photon release files
 Name:       photon-release
 Version:    3.0
-Release:    2%{?dist}
+Release:    3%{?dist}
 License:    Apache License
 Group:      System Environment/Base
 URL:        https://vmware.github.io/photon/
 Vendor:     VMware, Inc.
 Distribution:   Photon
+Provides:   system-release
+Provides:   system-release(%{version})
+Provides:   system-release(releasever) = %{version}
 BuildArch:  noarch
+
 
 %description
 Photon release files such as yum configs and other /etc/ release related files
@@ -42,11 +46,11 @@ EOF
 ln -sv ../usr/lib/os-release %{buildroot}/etc/os-release
 
 cat > %{buildroot}/etc/issue <<- EOF
-Welcome to Photon %{photon_release_version} (%{_arch}) - Kernel \r (\l)
+Welcome to Photon %{photon_release_version} (\m) - Kernel \r (\l)
 EOF
 
 cat > %{buildroot}/etc/issue.net <<- EOF
-Welcome to Photon %{photon_release_version} (%{_arch}) - Kernel %r (%t)
+Welcome to Photon %{photon_release_version} (%m) - Kernel %r (%t)
 EOF
 
 %post
@@ -64,6 +68,9 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/issue.net
 
 %changelog
+*       Sat Jan 04 2020 Neal Gompa <ngompa13@gmail.com> 3.0-3
+-       Fix issue files to not require arch mangling
+-       Add system-release Provides for generic distroverpkg identifying name
 *       Fri Sep 28 2018 Ajay Kaher <akaher@vmware.com> 3.0-2
 -       Fix for aarch64
 *       Mon Sep 24 2018 Anish Swaminathan <anishs@vmware.com> 3.0-1

--- a/SPECS/photon-repos/photon-debuginfo.repo
+++ b/SPECS/photon-repos/photon-debuginfo.repo
@@ -1,5 +1,5 @@
 [photon-debuginfo]
-name=VMware Photon Linux debuginfo 3.0(_arch)
+name=VMware Photon Linux debuginfo $releasever ($basearch)
 baseurl=https://dl.bintray.com/vmware/photon_debuginfo_$releasever_$basearch
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1

--- a/SPECS/photon-repos/photon-extras.repo
+++ b/SPECS/photon-repos/photon-extras.repo
@@ -1,5 +1,5 @@
 [photon-extras]
-name=VMware Photon Extras 3.0(_arch)
+name=VMware Photon Extras $releasever ($basearch)
 baseurl=https://dl.bintray.com/vmware/photon_extras_$releasever_$basearch
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1

--- a/SPECS/photon-repos/photon-iso.repo
+++ b/SPECS/photon-repos/photon-iso.repo
@@ -1,5 +1,5 @@
 [photon-iso]
-name=VMWare Photon Linux ISO 3.0(_arch)
+name=VMWare Photon Linux ISO $releasever ($basearch)
 baseurl=file:///mnt/cdrom/RPMS
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1

--- a/SPECS/photon-repos/photon-repos.spec
+++ b/SPECS/photon-repos/photon-repos.spec
@@ -1,7 +1,7 @@
 Summary:	Photon repo files, gpg keys
 Name:		photon-repos
 Version:	3.0
-Release:	2%{?dist}
+Release:	3%{?dist}
 License:	Apache License
 Group:		System Environment/Base
 URL:		https://vmware.github.io/photon/
@@ -20,9 +20,7 @@ BuildArch:	noarch
 Photon repo files and gpg keys 
 
 %build
-sed -i 's/_arch/%{_arch}/g' %{SOURCE1} \
-         %{SOURCE2} %{SOURCE3} \
-         %{SOURCE4} %{SOURCE5}
+# Nothing to do
 
 %install
 rm -rf $RPM_BUILD_ROOT
@@ -50,6 +48,8 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/yum.repos.d/photon-extras.repo
 
 %changelog
+*   Sat Jan 04 2020 Neal Gompa <ngompa13@gmail.com> 3.0-3
+-   Fix all the repo definitions to not require arch-specific mangling
 *   Mon Oct 1 2018 Ajay Kaher <akaher@vmware.com> 3.0-2
 -   Fix arch name in repos
 *   Mon Sep 24 2018 Anish Swaminathan <anishs@vmware.com> 3.0-1

--- a/SPECS/photon-repos/photon-updates.repo
+++ b/SPECS/photon-repos/photon-updates.repo
@@ -1,5 +1,5 @@
 [photon-updates]
-name=VMware Photon Linux 3.0(_arch) Updates
+name=VMware Photon Linux $releasever ($basearch) Updates
 baseurl=https://dl.bintray.com/vmware/photon_updates_$releasever_$basearch
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1

--- a/SPECS/photon-repos/photon.repo
+++ b/SPECS/photon-repos/photon.repo
@@ -1,5 +1,5 @@
 [photon]
-name=VMware Photon Linux 3.0(_arch)
+name=VMware Photon Linux $releasever ($basearch)
 baseurl=https://dl.bintray.com/vmware/photon_release_$releasever_$basearch
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1

--- a/SPECS/rpm/rpm.spec
+++ b/SPECS/rpm/rpm.spec
@@ -4,7 +4,7 @@
 Summary:        Package manager
 Name:           rpm
 Version:        4.14.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2+
 URL:            http://rpm.org
 Group:          Applications/System
@@ -107,6 +107,7 @@ sed -i 's/extra_link_args/library_dirs/g' python/setup.py.in
         --enable-python \
         --with-cap \
         --with-lua \
+        --with-vendor=vmware \
         --disable-silent-rules \
         --with-external-db
 make %{?_smp_mflags}
@@ -252,6 +253,8 @@ rm -rf %{buildroot}
 %{python3_sitelib}/*
 
 %changelog
+*   Sat Jan 04 2020 Neal Gompa <ngompa13@gmail.com> 4.14.2-7
+-   Configure RPMCANONVENDOR to vmware
 *   Thu Oct 31 2019 Alexey Makhalov <amakhalov@vmware.com> 4.14.2-6
 -   rpm-build depends on cpio
 *   Thu Oct 10 2019 Tapas Kundu <tkundu@vmware.com> 4.14.2-5


### PR DESCRIPTION
This PR includes simple fixes to enhance the Photon OS platform.

They are:

* `photon-release`: Remove arch mangling and add missing `system-release` Provides 
* `photon-repos`: Fix repo configs to not require arch-specific mangling
* `rpm`: Configure `RPMCANONVENDOR` to `vmware`

(For the rpm change, I debated between setting it to either `vmware` or `photon`. I expect `vmware` might be less surprising...)