### PR TITLE
Add RPM spec for HAProxy DataPlane API 1.2.5

### DIFF
--- a/SPECS/haproxy-dataplaneapi/haproxy-dataplaneapi.spec
+++ b/SPECS/haproxy-dataplaneapi/haproxy-dataplaneapi.spec
@@ -1,0 +1,60 @@
+# https://fedoraproject.org/wiki/PackagingDrafts/Go
+%global commit          284d34bb4aebf36df8ba1ad430adfd72c222d08b
+%global commitdate      20200415
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global repo            dataplaneapi
+%global cmd             %{repo}
+%global import_path     github.com/haproxytech/%{repo}
+%global repo_url        https://github.com/haproxytech/%{repo}
+%global source_url      %{repo_url}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
+%global build_date      %(date '+%%Y-%%m-%%dT%%H:%%M:%%S')
+# Required to avoid an error once integrating the Go Build ID.
+%global debug_package   %{nil}
+
+Summary:        A sidecar process for managing HAProxy.
+Name:           haproxy-%{repo}
+Version:        1.2.5
+Release:        1%{?dist}
+License:        Apache License 2.0
+URL:            %{repo_url}
+Group:          Applications/System
+Vendor:         VMware, Inc.
+Distribution:   Photon
+Source0:        %{source_url}
+%define sha1    %{repo}=9cfca3f7b240a51bb6e5995350a377aa6d7054f2
+BuildRequires:  go >= 1.13
+Requires:       haproxy >= 2.0.10
+
+%description
+HAProxy Data Plane API is a sidecar process that runs next to HAProxy
+and provides API endpoints for managing HAProxy.
+
+%prep
+%setup -n %{repo}-%{version}
+
+%build
+%define gcflags -N -l
+# The build_id and ldflags_for_build_id are the solution for the issue
+# that the Build ID in Go binaries:
+# - the issue       https://github.com/rpm-software-management/rpm/issues/367
+# - the work-around https://github.com/aws/amazon-ssm-agent/issues/268
+%define build_id %(head -c20 /dev/urandom|od -An -tx1|tr -d '[:space:]')
+%define ldflags_for_build_id -s -w -B 0x%{build_id} -extldflags=-Wl,-z,now,-z,relro,-z,defs
+%define ldflags_for_build_metadata -X main.GitRepo=%{source_url} -X main.GitTag=v%{version} -X main.GitCommit=%{commit} -X main.GitDirty= -X main.BuildTime=%{build_date}
+%define ldflags %{ldflags_for_build_id} %{ldflags_for_build_metadata}
+export CGO_ENABLED=0
+go build -gcflags "%{gcflags}" -ldflags "%{ldflags}" -o %{cmd} ./cmd/%{cmd}/
+
+%install
+install -m 755 -D %{cmd} %{buildroot}%{_libexecdir}/haproxy/%{cmd}
+
+%clean
+rm -rf %{buildroot}/*
+
+%files
+%defattr(-,root,root)
+%{_libexecdir}/haproxy/%{cmd}
+
+%changelog
+*   Mon Apr 20 2020 Andrew Kutz <akutz@vmware.com> 1.2.5
+-   Add haproxy-dataplaneapi v1.2.5 package.


### PR DESCRIPTION
This patch adds an RPM spec for building version 1.2.5 of the HAProxy DataPlane API sidecar. This should give Photon the ability to quickly consume DataPlane API 2.0 once it is released.

**Update**
I just built this using the [officially recommended method](https://github.com/vmware/photon/issues/1002#issuecomment-617344649) (thanks @suezzelur!), and it worked as well:

```shell
$ ls SPECS/haproxy-dataplaneapi
total 432
drwxr-xr-x    4 akutz  staff   128B Apr 21 14:32 ./
drwxr-xr-x  768 akutz  staff    24K Apr 21 14:25 ../
-rw-r--r--    1 akutz  staff   209K Apr 21 14:29 dataplaneapi-284d34b.tar.gz
-rw-r--r--    1 akutz  staff   2.2K Apr 21 14:25 haproxy-dataplaneapi.spec
```

```shell
$ ./tools/scripts/build_spec.sh $(pwd)/SPECS/haproxy-dataplaneapi/haproxy-dataplaneapi.spec
1. Create sandbox
	Use local build template image OK
2. Prepare build environment
	Create source folder OK
	Copy sources from /Users/akutz/Projects/photon/SPECS/haproxy-dataplaneapi OK
	Install build requirements OK
3. Build
	Run rpmbuild OK
4. Get binaries
	Copy RPMS OK
	Copy SRPMS OK
5. Destroy sandbox
	Stop container OK
	Remove container OK
Build completed. RPMS are in '/Users/akutz/Projects/photon/SPECS/haproxy-dataplaneapi/stage' folder
```

```shell
$ ls /Users/akutz/Projects/photon/SPECS/haproxy-dataplaneapi/stage/RPMS/x86_64/
total 10472
drwxr-xr-x  3 akutz  staff    96B Apr 21 14:30 ./
drwxr-xr-x  3 akutz  staff    96B Apr 21 14:30 ../
-rw-r--r--  1 akutz  staff   5.1M Apr 21 14:30 haproxy-dataplaneapi-1.2.5-1.ph3.x86_64.rpm
```

**Original Build Method**

To build this, I first started a container using the `Dockerfile` I mentioned in #1002:

```shell
docker run --rm -it \
  -v "$(pwd)/SPECS/haproxy-dataplaneapi":/usr/src/photon/SPECS/ \
  -v "$(pwd)/dataplaneapi-1.2.5.tar.gz":/usr/src/photon/SOURCES/dataplaneapi-284d34b.tar.gz:ro \
  photon-rpm-build
```

Then I run the following command (output included):

```shell
$ rpmbuild -ba SPECS/haproxy-dataplaneapi.spec 
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.CAQxaE
+ umask 022
+ cd /usr/src/photon/BUILD
+ cd /usr/src/photon/BUILD
+ rm -rf dataplaneapi-1.2.5
+ /bin/gzip -dc /usr/src/photon/SOURCES/dataplaneapi-284d34b.tar.gz
+ /bin/tar --no-same-owner -xvvof -
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/
-rw-rw-r-- root/root        45 2020-04-15 10:52 dataplaneapi-1.2.5/.gitignore
-rw-rw-r-- root/root      1935 2020-04-15 10:52 dataplaneapi-1.2.5/CONTRIBUTING.md
-rw-rw-r-- root/root     10173 2020-04-15 10:52 dataplaneapi-1.2.5/LICENSE
-rw-rw-r-- root/root       912 2020-04-15 10:52 dataplaneapi-1.2.5/Makefile
-rw-rw-r-- root/root      6174 2020-04-15 10:52 dataplaneapi-1.2.5/README.md
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/adapters/
-rw-rw-r-- root/root      4841 2020-04-15 10:52 dataplaneapi-1.2.5/adapters/adapters.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/assets/
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/assets/images/
-rw-rw-r-- root/root      7593 2020-04-15 10:52 dataplaneapi-1.2.5/assets/images/haproxy-weblogo-210x49.png
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/cmd/
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/cmd/dataplaneapi/
-rw-rw-r-- root/root      2624 2020-04-15 10:52 dataplaneapi-1.2.5/cmd/dataplaneapi/main.go
-rw-rw-r-- root/root       190 2020-04-15 10:52 dataplaneapi-1.2.5/cmd/dataplaneapi/version.go
-rw-rw-r-- root/root     27210 2020-04-15 10:52 dataplaneapi-1.2.5/configure_data_plane.go
-rw-rw-r-- root/root      1144 2020-04-15 10:52 dataplaneapi-1.2.5/doc.go
-rw-rw-r-- root/root    592748 2020-04-15 10:52 dataplaneapi-1.2.5/embedded_spec.go
-rw-rw-r-- root/root      1032 2020-04-15 10:52 dataplaneapi-1.2.5/go.mod
-rw-rw-r-- root/root     15656 2020-04-15 10:52 dataplaneapi-1.2.5/go.sum
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/
-rw-rw-r-- root/root      6723 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/acl.go
-rw-rw-r-- root/root      6871 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/backend.go
-rw-rw-r-- root/root      8116 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/backend_switching_rule.go
-rw-rw-r-- root/root      6694 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/bind.go
-rw-rw-r-- root/root      3172 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/defaults.go
-rw-rw-r-- root/root      6961 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/filter.go
-rw-rw-r-- root/root      7308 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/frontend.go
-rw-rw-r-- root/root      3106 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/global.go
-rw-rw-r-- root/root      7790 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/http_request_rule.go
-rw-rw-r-- root/root      7874 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/http_response_rule.go
-rw-rw-r-- root/root      4042 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/information.go
-rw-rw-r-- root/root      7277 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/log_target.go
-rw-rw-r-- root/root      2937 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/raw.go
-rw-rw-r-- root/root      1969 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/reloads.go
-rw-rw-r-- root/root      6497 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/runtime.go
-rw-rw-r-- root/root      7247 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/server.go
-rw-rw-r-- root/root      8018 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/server_switching_rule.go
-rw-rw-r-- root/root      6643 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/site.go
-rw-rw-r-- root/root      2836 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/stats.go
-rw-rw-r-- root/root      7147 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/stick_rule.go
-rw-rw-r-- root/root      7708 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/tcp_request_rule.go
-rw-rw-r-- root/root      7681 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/tcp_response_rule.go
-rw-rw-r-- root/root      4475 2020-04-15 10:52 dataplaneapi-1.2.5/handlers/transaction.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/haproxy/
-rw-rw-r-- root/root      8377 2020-04-15 10:52 dataplaneapi-1.2.5/haproxy/reload_agent.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/misc/
-rw-rw-r-- root/root      3056 2020-04-15 10:52 dataplaneapi-1.2.5/misc/misc.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/
-rw-rw-r-- root/root      2584 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/create_acl.go
-rw-rw-r-- root/root      7267 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/create_acl_parameters.go
-rw-rw-r-- root/root      9736 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/create_acl_responses.go
-rw-rw-r-- root/root      3758 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/create_acl_urlbuilder.go
-rw-rw-r-- root/root      2594 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/delete_acl.go
-rw-rw-r-- root/root      7270 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/delete_acl_parameters.go
-rw-rw-r-- root/root      6849 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/delete_acl_responses.go
-rw-rw-r-- root/root      3952 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/delete_acl_urlbuilder.go
-rw-rw-r-- root/root      3885 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acl.go
-rw-rw-r-- root/root      5210 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acl_parameters.go
-rw-rw-r-- root/root      6597 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acl_responses.go
-rw-rw-r-- root/root      3559 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acl_urlbuilder.go
-rw-rw-r-- root/root      3982 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acls.go
-rw-rw-r-- root/root      4559 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acls_parameters.go
-rw-rw-r-- root/root      4784 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acls_responses.go
-rw-rw-r-- root/root      3350 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/get_acls_urlbuilder.go
-rw-rw-r-- root/root      2613 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/replace_acl.go
-rw-rw-r-- root/root      7925 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/replace_acl_parameters.go
-rw-rw-r-- root/root      9764 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/replace_acl_responses.go
-rw-rw-r-- root/root      3966 2020-04-15 10:52 dataplaneapi-1.2.5/operations/acl/replace_acl_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/
-rw-rw-r-- root/root      2658 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/create_backend.go
-rw-rw-r-- root/root      5467 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/create_backend_parameters.go
-rw-rw-r-- root/root     10191 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/create_backend_responses.go
-rw-rw-r-- root/root      3592 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/create_backend_urlbuilder.go
-rw-rw-r-- root/root      2680 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/delete_backend.go
-rw-rw-r-- root/root      5374 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/delete_backend_parameters.go
-rw-rw-r-- root/root      7152 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/delete_backend_responses.go
-rw-rw-r-- root/root      3789 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/delete_backend_urlbuilder.go
-rw-rw-r-- root/root      4009 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backend.go
-rw-rw-r-- root/root      3281 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backend_parameters.go
-rw-rw-r-- root/root      6885 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backend_responses.go
-rw-rw-r-- root/root      3365 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backend_urlbuilder.go
-rw-rw-r-- root/root      4111 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backends.go
-rw-rw-r-- root/root      2745 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backends_parameters.go
-rw-rw-r-- root/root      4984 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backends_responses.go
-rw-rw-r-- root/root      3184 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/get_backends_urlbuilder.go
-rw-rw-r-- root/root      2691 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/replace_backend.go
-rw-rw-r-- root/root      6034 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/replace_backend_parameters.go
-rw-rw-r-- root/root     10219 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/replace_backend_responses.go
-rw-rw-r-- root/root      3803 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend/replace_backend_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/
-rw-rw-r-- root/root      3049 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/create_backend_switching_rule.go
-rw-rw-r-- root/root      6464 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/create_backend_switching_rule_parameters.go
-rw-rw-r-- root/root     11730 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/create_backend_switching_rule_responses.go
-rw-rw-r-- root/root      3895 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/create_backend_switching_rule_urlbuilder.go
-rw-rw-r-- root/root      3059 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/delete_backend_switching_rule.go
-rw-rw-r-- root/root      6456 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/delete_backend_switching_rule_parameters.go
-rw-rw-r-- root/root      8181 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/delete_backend_switching_rule_responses.go
-rw-rw-r-- root/root      4106 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/delete_backend_switching_rule_urlbuilder.go
-rw-rw-r-- root/root      4558 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rule.go
-rw-rw-r-- root/root      4351 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rule_parameters.go
-rw-rw-r-- root/root      7851 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rule_responses.go
-rw-rw-r-- root/root      3713 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rule_urlbuilder.go
-rw-rw-r-- root/root      4672 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rules.go
-rw-rw-r-- root/root      3675 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rules_parameters.go
-rw-rw-r-- root/root      5656 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rules_responses.go
-rw-rw-r-- root/root      3487 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/get_backend_switching_rules_urlbuilder.go
-rw-rw-r-- root/root      3078 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/replace_backend_switching_rule.go
-rw-rw-r-- root/root      7143 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/replace_backend_switching_rule_parameters.go
-rw-rw-r-- root/root     11758 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/replace_backend_switching_rule_responses.go
-rw-rw-r-- root/root      4120 2020-04-15 10:52 dataplaneapi-1.2.5/operations/backend_switching_rule/replace_backend_switching_rule_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/
-rw-rw-r-- root/root      2607 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/create_bind.go
-rw-rw-r-- root/root      6163 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/create_bind_parameters.go
-rw-rw-r-- root/root      9846 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/create_bind_responses.go
-rw-rw-r-- root/root      3649 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/create_bind_urlbuilder.go
-rw-rw-r-- root/root      2615 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/delete_bind.go
-rw-rw-r-- root/root      6070 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/delete_bind_parameters.go
-rw-rw-r-- root/root      6921 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/delete_bind_responses.go
-rw-rw-r-- root/root      3843 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/delete_bind_urlbuilder.go
-rw-rw-r-- root/root      3920 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_bind.go
-rw-rw-r-- root/root      3983 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_bind_parameters.go
-rw-rw-r-- root/root      6670 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_bind_responses.go
-rw-rw-r-- root/root      3419 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_bind_urlbuilder.go
-rw-rw-r-- root/root      4022 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_binds.go
-rw-rw-r-- root/root      3454 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_binds_parameters.go
-rw-rw-r-- root/root      4834 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_binds_responses.go
-rw-rw-r-- root/root      3241 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/get_binds_urlbuilder.go
-rw-rw-r-- root/root      2636 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/replace_bind.go
-rw-rw-r-- root/root      6725 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/replace_bind_parameters.go
-rw-rw-r-- root/root      9874 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/replace_bind_responses.go
-rw-rw-r-- root/root      3857 2020-04-15 10:52 dataplaneapi-1.2.5/operations/bind/replace_bind_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/
-rw-rw-r-- root/root      4317 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/get_h_a_proxy_configuration.go
-rw-rw-r-- root/root      3781 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/get_h_a_proxy_configuration_parameters.go
-rw-rw-r-- root/root      5608 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/get_h_a_proxy_configuration_responses.go
-rw-rw-r-- root/root      3537 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/get_h_a_proxy_configuration_urlbuilder.go
-rw-rw-r-- root/root      2939 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/post_h_a_proxy_configuration.go
-rw-rw-r-- root/root      4718 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/post_h_a_proxy_configuration_parameters.go
-rw-rw-r-- root/root      9070 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/post_h_a_proxy_configuration_responses.go
-rw-rw-r-- root/root      3547 2020-04-15 10:52 dataplaneapi-1.2.5/operations/configuration/post_h_a_proxy_configuration_urlbuilder.go
-rw-rw-r-- root/root     91011 2020-04-15 10:52 dataplaneapi-1.2.5/operations/data_plane_api.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/
-rw-rw-r-- root/root      4051 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/get_defaults.go
-rw-rw-r-- root/root      2746 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/get_defaults_parameters.go
-rw-rw-r-- root/root      4985 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/get_defaults_responses.go
-rw-rw-r-- root/root      3185 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/get_defaults_urlbuilder.go
-rw-rw-r-- root/root      2692 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/replace_defaults.go
-rw-rw-r-- root/root      5500 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/replace_defaults_parameters.go
-rw-rw-r-- root/root      8274 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/replace_defaults_responses.go
-rw-rw-r-- root/root      3619 2020-04-15 10:52 dataplaneapi-1.2.5/operations/defaults/replace_defaults_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/
-rw-rw-r-- root/root      2673 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_api_endpoints.go
-rw-rw-r-- root/root      1922 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_api_endpoints_parameters.go
-rw-rw-r-- root/root      4420 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_api_endpoints_responses.go
-rw-rw-r-- root/root      2917 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_api_endpoints_urlbuilder.go
-rw-rw-r-- root/root      3001 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_configuration_endpoints.go
-rw-rw-r-- root/root      2032 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_configuration_endpoints_parameters.go
-rw-rw-r-- root/root      4830 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_configuration_endpoints_responses.go
-rw-rw-r-- root/root      3077 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_configuration_endpoints_urlbuilder.go
-rw-rw-r-- root/root      2799 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_haproxy_endpoints.go
-rw-rw-r-- root/root      1966 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_haproxy_endpoints_parameters.go
-rw-rw-r-- root/root      4584 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_haproxy_endpoints_responses.go
-rw-rw-r-- root/root      2985 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_haproxy_endpoints_urlbuilder.go
-rw-rw-r-- root/root      2810 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_services_endpoints.go
-rw-rw-r-- root/root      1977 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_services_endpoints_parameters.go
-rw-rw-r-- root/root      4625 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_services_endpoints_responses.go
-rw-rw-r-- root/root      2990 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_services_endpoints_urlbuilder.go
-rw-rw-r-- root/root      2757 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_stats_endpoints.go
-rw-rw-r-- root/root      1944 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_stats_endpoints_parameters.go
-rw-rw-r-- root/root      4502 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_stats_endpoints_responses.go
-rw-rw-r-- root/root      2965 2020-04-15 10:52 dataplaneapi-1.2.5/operations/discovery/get_stats_endpoints_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/
-rw-rw-r-- root/root      2655 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/create_filter.go
-rw-rw-r-- root/root      7330 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/create_filter_parameters.go
-rw-rw-r-- root/root     10076 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/create_filter_responses.go
-rw-rw-r-- root/root      3803 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/create_filter_urlbuilder.go
-rw-rw-r-- root/root      2665 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/delete_filter.go
-rw-rw-r-- root/root      7328 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/delete_filter_parameters.go
-rw-rw-r-- root/root      7075 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/delete_filter_responses.go
-rw-rw-r-- root/root      4000 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/delete_filter_urlbuilder.go
-rw-rw-r-- root/root      3992 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filter.go
-rw-rw-r-- root/root      5259 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filter_parameters.go
-rw-rw-r-- root/root      6813 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filter_responses.go
-rw-rw-r-- root/root      3607 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filter_urlbuilder.go
-rw-rw-r-- root/root      4092 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filters.go
-rw-rw-r-- root/root      4607 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filters_parameters.go
-rw-rw-r-- root/root      4934 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filters_responses.go
-rw-rw-r-- root/root      3395 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/get_filters_urlbuilder.go
-rw-rw-r-- root/root      2684 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/replace_filter.go
-rw-rw-r-- root/root      7989 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/replace_filter_parameters.go
-rw-rw-r-- root/root     10104 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/replace_filter_responses.go
-rw-rw-r-- root/root      4014 2020-04-15 10:52 dataplaneapi-1.2.5/operations/filter/replace_filter_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/
-rw-rw-r-- root/root      2685 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/create_frontend.go
-rw-rw-r-- root/root      5485 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/create_frontend_parameters.go
-rw-rw-r-- root/root     10306 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/create_frontend_responses.go
-rw-rw-r-- root/root      3607 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/create_frontend_urlbuilder.go
-rw-rw-r-- root/root      2706 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/delete_frontend.go
-rw-rw-r-- root/root      5392 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/delete_frontend_parameters.go
-rw-rw-r-- root/root      7229 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/delete_frontend_responses.go
-rw-rw-r-- root/root      3805 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/delete_frontend_urlbuilder.go
-rw-rw-r-- root/root      4048 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontend.go
-rw-rw-r-- root/root      3296 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontend_parameters.go
-rw-rw-r-- root/root      6957 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontend_responses.go
-rw-rw-r-- root/root      3381 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontend_urlbuilder.go
-rw-rw-r-- root/root      4151 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontends.go
-rw-rw-r-- root/root      2758 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontends_parameters.go
-rw-rw-r-- root/root      5034 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontends_responses.go
-rw-rw-r-- root/root      3199 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/get_frontends_urlbuilder.go
-rw-rw-r-- root/root      2718 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/replace_frontend.go
-rw-rw-r-- root/root      6054 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/replace_frontend_parameters.go
-rw-rw-r-- root/root     10334 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/replace_frontend_responses.go
-rw-rw-r-- root/root      3819 2020-04-15 10:52 dataplaneapi-1.2.5/operations/frontend/replace_frontend_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/
-rw-rw-r-- root/root      3975 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/get_global.go
-rw-rw-r-- root/root      2720 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/get_global_parameters.go
-rw-rw-r-- root/root      4885 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/get_global_responses.go
-rw-rw-r-- root/root      3155 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/get_global_urlbuilder.go
-rw-rw-r-- root/root      2638 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/replace_global.go
-rw-rw-r-- root/root      5464 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/replace_global_parameters.go
-rw-rw-r-- root/root      8088 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/replace_global_responses.go
-rw-rw-r-- root/root      3589 2020-04-15 10:52 dataplaneapi-1.2.5/operations/global/replace_global_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/
-rw-rw-r-- root/root      2912 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/create_http_request_rule.go
-rw-rw-r-- root/root      7523 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/create_http_request_rule_parameters.go
-rw-rw-r-- root/root     11155 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/create_http_request_rule_responses.go
-rw-rw-r-- root/root      3944 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/create_http_request_rule_urlbuilder.go
-rw-rw-r-- root/root      2922 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/delete_http_request_rule.go
-rw-rw-r-- root/root      7523 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/delete_http_request_rule_parameters.go
-rw-rw-r-- root/root      7796 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/delete_http_request_rule_responses.go
-rw-rw-r-- root/root      4150 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/delete_http_request_rule_urlbuilder.go
-rw-rw-r-- root/root      4361 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rule.go
-rw-rw-r-- root/root      5427 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rule_parameters.go
-rw-rw-r-- root/root      7491 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rule_responses.go
-rw-rw-r-- root/root      3757 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rule_urlbuilder.go
-rw-rw-r-- root/root      4470 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rules.go
-rw-rw-r-- root/root      4755 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rules_parameters.go
-rw-rw-r-- root/root      5406 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rules_responses.go
-rw-rw-r-- root/root      3536 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/get_http_request_rules_urlbuilder.go
-rw-rw-r-- root/root      2941 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/replace_http_request_rule.go
-rw-rw-r-- root/root      8202 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/replace_http_request_rule_parameters.go
-rw-rw-r-- root/root     11183 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/replace_http_request_rule_responses.go
-rw-rw-r-- root/root      4164 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_request_rule/replace_http_request_rule_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/
-rw-rw-r-- root/root      2939 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/create_http_response_rule.go
-rw-rw-r-- root/root      7544 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/create_http_response_rule_parameters.go
-rw-rw-r-- root/root     11270 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/create_http_response_rule_responses.go
-rw-rw-r-- root/root      3959 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/create_http_response_rule_urlbuilder.go
-rw-rw-r-- root/root      2949 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/delete_http_response_rule.go
-rw-rw-r-- root/root      7544 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/delete_http_response_rule_parameters.go
-rw-rw-r-- root/root      7873 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/delete_http_response_rule_responses.go
-rw-rw-r-- root/root      4166 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/delete_http_response_rule_urlbuilder.go
-rw-rw-r-- root/root      4400 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rule.go
-rw-rw-r-- root/root      5445 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rule_parameters.go
-rw-rw-r-- root/root      7563 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rule_responses.go
-rw-rw-r-- root/root      3773 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rule_urlbuilder.go
-rw-rw-r-- root/root      4510 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rules.go
-rw-rw-r-- root/root      4771 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rules_parameters.go
-rw-rw-r-- root/root      5456 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rules_responses.go
-rw-rw-r-- root/root      3551 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/get_http_response_rules_urlbuilder.go
-rw-rw-r-- root/root      2968 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/replace_http_response_rule.go
-rw-rw-r-- root/root      8225 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/replace_http_response_rule_parameters.go
-rw-rw-r-- root/root     11298 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/replace_http_response_rule_responses.go
-rw-rw-r-- root/root      4180 2020-04-15 10:52 dataplaneapi-1.2.5/operations/http_response_rule/replace_http_response_rule_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/
-rw-rw-r-- root/root      2839 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_haproxy_process_info.go
-rw-rw-r-- root/root      1991 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_haproxy_process_info_parameters.go
-rw-rw-r-- root/root      4635 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_haproxy_process_info_responses.go
-rw-rw-r-- root/root      3019 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_haproxy_process_info_urlbuilder.go
-rw-rw-r-- root/root      2518 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_info.go
-rw-rw-r-- root/root      1835 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_info_parameters.go
-rw-rw-r-- root/root      4024 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_info_responses.go
-rw-rw-r-- root/root      2818 2020-04-15 10:52 dataplaneapi-1.2.5/operations/information/get_info_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/
-rw-rw-r-- root/root      2743 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/create_log_target.go
-rw-rw-r-- root/root      7395 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/create_log_target_parameters.go
-rw-rw-r-- root/root     10443 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/create_log_target_responses.go
-rw-rw-r-- root/root      3851 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/create_log_target_urlbuilder.go
-rw-rw-r-- root/root      2753 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/delete_log_target.go
-rw-rw-r-- root/root      7394 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/delete_log_target_parameters.go
-rw-rw-r-- root/root      7320 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/delete_log_target_responses.go
-rw-rw-r-- root/root      4051 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/delete_log_target_urlbuilder.go
-rw-rw-r-- root/root      4118 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_target.go
-rw-rw-r-- root/root      5316 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_target_parameters.go
-rw-rw-r-- root/root      7044 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_target_responses.go
-rw-rw-r-- root/root      3658 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_target_urlbuilder.go
-rw-rw-r-- root/root      4221 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_targets.go
-rw-rw-r-- root/root      4657 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_targets_parameters.go
-rw-rw-r-- root/root      5095 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_targets_responses.go
-rw-rw-r-- root/root      3443 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/get_log_targets_urlbuilder.go
-rw-rw-r-- root/root      2772 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/replace_log_target.go
-rw-rw-r-- root/root      8061 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/replace_log_target_parameters.go
-rw-rw-r-- root/root     10471 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/replace_log_target_responses.go
-rw-rw-r-- root/root      4065 2020-04-15 10:52 dataplaneapi-1.2.5/operations/log_target/replace_log_target_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/
-rw-rw-r-- root/root      2567 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reload.go
-rw-rw-r-- root/root      2796 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reload_parameters.go
-rw-rw-r-- root/root      6049 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reload_responses.go
-rw-rw-r-- root/root      3073 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reload_urlbuilder.go
-rw-rw-r-- root/root      2583 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reloads.go
-rw-rw-r-- root/root      1864 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reloads_parameters.go
-rw-rw-r-- root/root      4197 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reloads_responses.go
-rw-rw-r-- root/root      2873 2020-04-15 10:52 dataplaneapi-1.2.5/operations/reloads/get_reloads_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/
-rw-rw-r-- root/root      2660 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/create_server.go
-rw-rw-r-- root/root      6187 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/create_server_parameters.go
-rw-rw-r-- root/root     10076 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/create_server_responses.go
-rw-rw-r-- root/root      3674 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/create_server_urlbuilder.go
-rw-rw-r-- root/root      2668 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/delete_server.go
-rw-rw-r-- root/root      6094 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/delete_server_parameters.go
-rw-rw-r-- root/root      7075 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/delete_server_responses.go
-rw-rw-r-- root/root      3870 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/delete_server_urlbuilder.go
-rw-rw-r-- root/root      3997 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_server.go
-rw-rw-r-- root/root      4001 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_server_parameters.go
-rw-rw-r-- root/root      6813 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_server_responses.go
-rw-rw-r-- root/root      3446 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_server_urlbuilder.go
-rw-rw-r-- root/root      4101 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_servers.go
-rw-rw-r-- root/root      3468 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_servers_parameters.go
-rw-rw-r-- root/root      4934 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_servers_responses.go
-rw-rw-r-- root/root      3266 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/get_servers_urlbuilder.go
-rw-rw-r-- root/root      2689 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/replace_server.go
-rw-rw-r-- root/root      6753 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/replace_server_parameters.go
-rw-rw-r-- root/root     10104 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/replace_server_responses.go
-rw-rw-r-- root/root      3884 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server/replace_server_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/
-rw-rw-r-- root/root      3021 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/create_server_switching_rule.go
-rw-rw-r-- root/root      6431 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/create_server_switching_rule_parameters.go
-rw-rw-r-- root/root     11615 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/create_server_switching_rule_responses.go
-rw-rw-r-- root/root      3875 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/create_server_switching_rule_urlbuilder.go
-rw-rw-r-- root/root      3031 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/delete_server_switching_rule.go
-rw-rw-r-- root/root      6424 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/delete_server_switching_rule_parameters.go
-rw-rw-r-- root/root      8104 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/delete_server_switching_rule_responses.go
-rw-rw-r-- root/root      4085 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/delete_server_switching_rule_urlbuilder.go
-rw-rw-r-- root/root      4518 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rule.go
-rw-rw-r-- root/root      4322 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rule_parameters.go
-rw-rw-r-- root/root      7779 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rule_responses.go
-rw-rw-r-- root/root      3692 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rule_urlbuilder.go
-rw-rw-r-- root/root      4632 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rules.go
-rw-rw-r-- root/root      3647 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rules_parameters.go
-rw-rw-r-- root/root      5606 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rules_responses.go
-rw-rw-r-- root/root      3467 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/get_server_switching_rules_urlbuilder.go
-rw-rw-r-- root/root      3050 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/replace_server_switching_rule.go
-rw-rw-r-- root/root      7109 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/replace_server_switching_rule_parameters.go
-rw-rw-r-- root/root     11643 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/replace_server_switching_rule_responses.go
-rw-rw-r-- root/root      4099 2020-04-15 10:52 dataplaneapi-1.2.5/operations/server_switching_rule/replace_server_switching_rule_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/
-rw-rw-r-- root/root      2565 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/create_site.go
-rw-rw-r-- root/root      5414 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/create_site_parameters.go
-rw-rw-r-- root/root      9847 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/create_site_responses.go
-rw-rw-r-- root/root      3534 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/create_site_urlbuilder.go
-rw-rw-r-- root/root      2586 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/delete_site.go
-rw-rw-r-- root/root      5330 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/delete_site_parameters.go
-rw-rw-r-- root/root      6922 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/delete_site_responses.go
-rw-rw-r-- root/root      3728 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/delete_site_urlbuilder.go
-rw-rw-r-- root/root      3880 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_site.go
-rw-rw-r-- root/root      3246 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_site_parameters.go
-rw-rw-r-- root/root      6670 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_site_responses.go
-rw-rw-r-- root/root      3304 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_site_urlbuilder.go
-rw-rw-r-- root/root      3979 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_sites.go
-rw-rw-r-- root/root      2707 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_sites_parameters.go
-rw-rw-r-- root/root      4835 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_sites_responses.go
-rw-rw-r-- root/root      3126 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/get_sites_urlbuilder.go
-rw-rw-r-- root/root      2598 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/replace_site.go
-rw-rw-r-- root/root      5984 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/replace_site_parameters.go
-rw-rw-r-- root/root      9875 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/replace_site_responses.go
-rw-rw-r-- root/root      3742 2020-04-15 10:52 dataplaneapi-1.2.5/operations/sites/replace_site_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/specification/
-rw-rw-r-- root/root      2722 2020-04-15 10:52 dataplaneapi-1.2.5/operations/specification/get_specification.go
-rw-rw-r-- root/root      1936 2020-04-15 10:52 dataplaneapi-1.2.5/operations/specification/get_specification_parameters.go
-rw-rw-r-- root/root      4362 2020-04-15 10:52 dataplaneapi-1.2.5/operations/specification/get_specification_responses.go
-rw-rw-r-- root/root      2946 2020-04-15 10:52 dataplaneapi-1.2.5/operations/specification/get_specification_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stats/
-rw-rw-r-- root/root      2516 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stats/get_stats.go
-rw-rw-r-- root/root      4175 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stats/get_stats_parameters.go
-rw-rw-r-- root/root      5492 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stats/get_stats_responses.go
-rw-rw-r-- root/root      3322 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stats/get_stats_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/
-rw-rw-r-- root/root      2744 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/create_stick_rule.go
-rw-rw-r-- root/root      6239 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/create_stick_rule_parameters.go
-rw-rw-r-- root/root     10443 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/create_stick_rule_responses.go
-rw-rw-r-- root/root      3722 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/create_stick_rule_urlbuilder.go
-rw-rw-r-- root/root      2754 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/delete_stick_rule.go
-rw-rw-r-- root/root      6238 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/delete_stick_rule_parameters.go
-rw-rw-r-- root/root      7320 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/delete_stick_rule_responses.go
-rw-rw-r-- root/root      3922 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/delete_stick_rule_urlbuilder.go
-rw-rw-r-- root/root      4119 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rule.go
-rw-rw-r-- root/root      4166 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rule_parameters.go
-rw-rw-r-- root/root      7044 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rule_responses.go
-rw-rw-r-- root/root      3529 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rule_urlbuilder.go
-rw-rw-r-- root/root      4222 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rules.go
-rw-rw-r-- root/root      3505 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rules_parameters.go
-rw-rw-r-- root/root      5095 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rules_responses.go
-rw-rw-r-- root/root      3314 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/get_stick_rules_urlbuilder.go
-rw-rw-r-- root/root      2773 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/replace_stick_rule.go
-rw-rw-r-- root/root      6903 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/replace_stick_rule_parameters.go
-rw-rw-r-- root/root     10471 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/replace_stick_rule_responses.go
-rw-rw-r-- root/root      3936 2020-04-15 10:52 dataplaneapi-1.2.5/operations/stick_rule/replace_stick_rule_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/
-rw-rw-r-- root/root      2885 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/create_tcp_request_rule.go
-rw-rw-r-- root/root      7502 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/create_tcp_request_rule_parameters.go
-rw-rw-r-- root/root     11040 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/create_tcp_request_rule_responses.go
-rw-rw-r-- root/root      3929 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/create_tcp_request_rule_urlbuilder.go
-rw-rw-r-- root/root      2895 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/delete_tcp_request_rule.go
-rw-rw-r-- root/root      7502 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/delete_tcp_request_rule_parameters.go
-rw-rw-r-- root/root      7719 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/delete_tcp_request_rule_responses.go
-rw-rw-r-- root/root      4134 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/delete_tcp_request_rule_urlbuilder.go
-rw-rw-r-- root/root      4322 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rule.go
-rw-rw-r-- root/root      5409 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rule_parameters.go
-rw-rw-r-- root/root      7419 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rule_responses.go
-rw-rw-r-- root/root      3741 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rule_urlbuilder.go
-rw-rw-r-- root/root      4446 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rules.go
-rw-rw-r-- root/root      4739 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rules_parameters.go
-rw-rw-r-- root/root      5356 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rules_responses.go
-rw-rw-r-- root/root      3521 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/get_tcp_request_rules_urlbuilder.go
-rw-rw-r-- root/root      2914 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/replace_tcp_request_rule.go
-rw-rw-r-- root/root      8179 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/replace_tcp_request_rule_parameters.go
-rw-rw-r-- root/root     11068 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/replace_tcp_request_rule_responses.go
-rw-rw-r-- root/root      4148 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_request_rule/replace_tcp_request_rule_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/
-rw-rw-r-- root/root      2913 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/create_tcp_response_rule.go
-rw-rw-r-- root/root      6362 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/create_tcp_response_rule_parameters.go
-rw-rw-r-- root/root     11155 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/create_tcp_response_rule_responses.go
-rw-rw-r-- root/root      3815 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/create_tcp_response_rule_urlbuilder.go
-rw-rw-r-- root/root      2923 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/delete_tcp_response_rule.go
-rw-rw-r-- root/root      6362 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/delete_tcp_response_rule_parameters.go
-rw-rw-r-- root/root      7796 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/delete_tcp_response_rule_responses.go
-rw-rw-r-- root/root      4021 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/delete_tcp_response_rule_urlbuilder.go
-rw-rw-r-- root/root      4362 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rule.go
-rw-rw-r-- root/root      4272 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rule_parameters.go
-rw-rw-r-- root/root      7491 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rule_responses.go
-rw-rw-r-- root/root      3628 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rule_urlbuilder.go
-rw-rw-r-- root/root      4471 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rules.go
-rw-rw-r-- root/root      3598 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rules_parameters.go
-rw-rw-r-- root/root      5406 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rules_responses.go
-rw-rw-r-- root/root      3407 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/get_tcp_response_rules_urlbuilder.go
-rw-rw-r-- root/root      2942 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/replace_tcp_response_rule.go
-rw-rw-r-- root/root      7039 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/replace_tcp_response_rule_parameters.go
-rw-rw-r-- root/root     11183 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/replace_tcp_response_rule_responses.go
-rw-rw-r-- root/root      4035 2020-04-15 10:52 dataplaneapi-1.2.5/operations/tcp_response_rule/replace_tcp_response_rule_urlbuilder.go
drwxrwxr-x root/root         0 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/
-rw-rw-r-- root/root      2782 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/commit_transaction.go
-rw-rw-r-- root/root      3812 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/commit_transaction_parameters.go
-rw-rw-r-- root/root     10585 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/commit_transaction_responses.go
-rw-rw-r-- root/root      3472 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/commit_transaction_urlbuilder.go
-rw-rw-r-- root/root      2737 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/delete_transaction.go
-rw-rw-r-- root/root      2522 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/delete_transaction_parameters.go
-rw-rw-r-- root/root      6134 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/delete_transaction_responses.go
-rw-rw-r-- root/root      3195 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/delete_transaction_urlbuilder.go
-rw-rw-r-- root/root      2718 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transaction.go
-rw-rw-r-- root/root      2486 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transaction_parameters.go
-rw-rw-r-- root/root      6384 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transaction_responses.go
-rw-rw-r-- root/root      3153 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transaction_urlbuilder.go
-rw-rw-r-- root/root      2792 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transactions.go
-rw-rw-r-- root/root      3035 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transactions_parameters.go
-rw-rw-r-- root/root      4427 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transactions_responses.go
-rw-rw-r-- root/root      3174 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/get_transactions_urlbuilder.go
-rw-rw-r-- root/root      2733 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/start_transaction.go
-rw-rw-r-- root/root      2962 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/start_transaction_parameters.go
-rw-rw-r-- root/root      4510 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/start_transaction_responses.go
-rw-rw-r-- root/root      3195 2020-04-15 10:52 dataplaneapi-1.2.5/operations/transactions/start_transaction_urlbuilder.go
-rw-rw-r-- root/root     16138 2020-04-15 10:52 dataplaneapi-1.2.5/server.go
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd dataplaneapi-1.2.5
+ /bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.gCbMeo
+ umask 022
+ cd /usr/src/photon/BUILD
+ cd dataplaneapi-1.2.5
+ export CGO_ENABLED=0
+ CGO_ENABLED=0
+ go build -gcflags '-N -l' -ldflags '-s -w -B 0x05362c6d3b15936eee9b5f6a69857dc781d0b91c -extldflags=-Wl,-z,now,-z,relro,-z,defs -X main.GitRepo=dataplaneapi -X main.GitTag=v1.2.5 -X main.GitCommit=284d34bb4aebf36df8ba1ad430adfd72c222d08b -X main.GitDirty= -X main.BuildTime=2020-04-21T19:11:40' -o dataplaneapi ./cmd/dataplaneapi/
go: downloading github.com/go-openapi/loads v0.19.0
go: downloading github.com/haproxytech/client-native v1.2.7
go: downloading github.com/go-openapi/strfmt v0.19.0
go: downloading github.com/haproxytech/models v1.2.5-0.20191122125615-30d0235b81ec
go: downloading github.com/go-openapi/errors v0.19.0
go: downloading github.com/go-openapi/runtime v0.19.0
go: downloading github.com/go-openapi/spec v0.19.0
go: downloading golang.org/x/sys v0.0.0-20190422165155-953cdadca894
go: downloading github.com/sirupsen/logrus v1.4.2
go: extracting github.com/go-openapi/errors v0.19.0
go: extracting github.com/go-openapi/loads v0.19.0
go: extracting github.com/go-openapi/strfmt v0.19.0
go: downloading github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
go: downloading github.com/rs/cors v1.6.0
go: extracting github.com/sirupsen/logrus v1.4.2
go: downloading github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
go: extracting github.com/haproxytech/models v1.2.5-0.20191122125615-30d0235b81ec
go: extracting github.com/haproxytech/client-native v1.2.7
go: extracting github.com/go-openapi/runtime v0.19.0
go: extracting github.com/go-openapi/spec v0.19.0
go: downloading github.com/shirou/gopsutil v2.18.12+incompatible
go: downloading github.com/jessevdk/go-flags v1.4.0
go: downloading github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe
go: extracting github.com/rs/cors v1.6.0
go: downloading github.com/haproxytech/config-parser v1.2.0
go: downloading github.com/docker/go-units v0.4.0
go: extracting github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
go: downloading github.com/go-openapi/jsonpointer v0.18.0
go: extracting github.com/jessevdk/go-flags v1.4.0
go: extracting github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe
go: extracting github.com/docker/go-units v0.4.0
go: extracting github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
go: downloading github.com/GehirnInc/crypt v0.0.0-20190301055215-6c0105aabd46
go: extracting github.com/shirou/gopsutil v2.18.12+incompatible
go: extracting github.com/go-openapi/jsonpointer v0.18.0
go: extracting github.com/haproxytech/config-parser v1.2.0
go: extracting github.com/GehirnInc/crypt v0.0.0-20190301055215-6c0105aabd46
go: downloading github.com/go-openapi/jsonreference v0.18.0
go: downloading github.com/mitchellh/mapstructure v1.1.2
go: downloading github.com/go-openapi/analysis v0.18.0
go: downloading github.com/go-openapi/validate v0.19.0
go: downloading golang.org/x/net v0.0.0-20190607181551-461777fb6f67
go: downloading github.com/pkg/errors v0.8.1
go: downloading github.com/google/uuid v1.1.1
go: downloading github.com/go-openapi/swag v0.19.0
go: extracting github.com/go-openapi/jsonreference v0.18.0
go: extracting golang.org/x/sys v0.0.0-20190422165155-953cdadca894
go: downloading github.com/PuerkitoBio/purell v1.1.1
go: extracting github.com/mitchellh/mapstructure v1.1.2
go: extracting github.com/google/uuid v1.1.1
go: extracting github.com/pkg/errors v0.8.1
go: extracting github.com/go-openapi/analysis v0.18.0
go: extracting github.com/go-openapi/swag v0.19.0
go: downloading gopkg.in/yaml.v2 v2.2.2
go: extracting github.com/go-openapi/validate v0.19.0
go: extracting github.com/PuerkitoBio/purell v1.1.1
go: downloading github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
go: downloading golang.org/x/text v0.3.0
go: extracting gopkg.in/yaml.v2 v2.2.2
go: extracting github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
go: extracting golang.org/x/net v0.0.0-20190607181551-461777fb6f67
go: extracting golang.org/x/text v0.3.0
go: finding github.com/jessevdk/go-flags v1.4.0
go: finding github.com/go-openapi/loads v0.19.0
go: finding github.com/go-openapi/errors v0.19.0
go: finding github.com/sirupsen/logrus v1.4.2
go: finding github.com/go-openapi/runtime v0.19.0
go: finding github.com/go-openapi/spec v0.19.0
go: finding github.com/go-openapi/analysis v0.18.0
go: finding github.com/go-openapi/strfmt v0.19.0
go: finding github.com/GehirnInc/crypt v0.0.0-20190301055215-6c0105aabd46
go: finding github.com/go-openapi/swag v0.19.0
go: finding github.com/go-openapi/jsonpointer v0.18.0
go: finding golang.org/x/sys v0.0.0-20190422165155-953cdadca894
go: finding github.com/docker/go-units v0.4.0
go: finding github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
go: finding github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe
go: finding github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
go: finding github.com/go-openapi/jsonreference v0.18.0
go: finding github.com/go-openapi/validate v0.19.0
go: finding github.com/haproxytech/client-native v1.2.7
go: finding gopkg.in/yaml.v2 v2.2.2
go: finding github.com/haproxytech/models v1.2.5-0.20191122125615-30d0235b81ec
go: finding github.com/PuerkitoBio/purell v1.1.1
go: finding github.com/haproxytech/config-parser v1.2.0
go: finding github.com/mitchellh/mapstructure v1.1.2
go: finding github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
go: finding github.com/google/uuid v1.1.1
go: finding golang.org/x/net v0.0.0-20190607181551-461777fb6f67
go: finding golang.org/x/text v0.3.0
go: finding github.com/rs/cors v1.6.0
go: finding github.com/pkg/errors v0.8.1
go: finding github.com/shirou/gopsutil v2.18.12+incompatible
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.pAn0Nc
+ umask 022
+ cd /usr/src/photon/BUILD
+ cd dataplaneapi-1.2.5
+ install -m 755 -D dataplaneapi /usr/src/photon/BUILDROOT/haproxy-dataplaneapi-1.2.5-1.x86_64/usr/bin/dataplaneapi
+ /usr/lib/rpm/brp-compress
+ /usr/lib/rpm/brp-strip /bin/strip
+ /usr/lib/rpm/brp-strip-debug-symbols /bin/strip
+ /usr/lib/rpm/brp-strip-comment-note /bin/strip /bin/objdump
+ /usr/lib/rpm/brp-strip-unneeded /bin/strip
+ /usr/lib/rpm/brp-strip-static-archive /bin/strip
Processing files: haproxy-dataplaneapi-1.2.5-1.x86_64
Provides: haproxy-dataplaneapi = 1.2.5-1 haproxy-dataplaneapi(x86-64) = 1.2.5-1
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /usr/src/photon/BUILDROOT/haproxy-dataplaneapi-1.2.5-1.x86_64
Wrote: /usr/src/photon/SRPMS/haproxy-dataplaneapi-1.2.5-1.src.rpm
Wrote: /usr/src/photon/RPMS/x86_64/haproxy-dataplaneapi-1.2.5-1.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.s2m9Rc
+ umask 022
+ cd /usr/src/photon/BUILD
+ cd dataplaneapi-1.2.5
+ rm -rf /usr/src/photon/BUILDROOT/haproxy-dataplaneapi-1.2.5-1.x86_64/usr
+ exit 0
```

The RPM produced includes the DataPlane API binary:

```shell
$rpm -ql RPMS/x86_64/haproxy-dataplaneapi-1.2.5-1.x86_64.rpm 
/usr/bin/dataplaneapi
```

cc @maplain @andrewsykim @ppadmavilasom @markrj @derekbeard 