### PR TITLE
Improve create ebs image script

### DIFF
--- a/support/image-builder/ami/create-ebs-image.sh
+++ b/support/image-builder/ami/create-ebs-image.sh
@@ -167,7 +167,7 @@ done
 sleep $SSH_WAIT
 
 while : ; do
- output=$(eval ssh -o StrictHostKeyChecking=no -i $KEY_FILE root@$IP 'tdnf install -y kpartx wget')
+ output=$(eval ssh -o StrictHostKeyChecking=no -i $KEY_FILE ec2-user@$IP 'sudo yum install -y kpartx wget')
  ret=$?
  if [ "$ret" -eq 0 ]; then
   break


### PR DESCRIPTION
This refactors parts of this script to make it a little more recent.

The breaking change here is that you must explicitly declare a VPC and subnet.

Uses an Amazon Linux 2 AMI instead of a photon AMI, since photon doesn't exist in all regions yet.