### PR TITLE
Allow install on Xen

### DIFF
--- a/installer/device.py
+++ b/installer/device.py
@@ -13,7 +13,7 @@ class Device(object):
 
     @staticmethod
     def refresh_devices():
-        devices_list = subprocess.check_output(['lsblk', '-d', '-I', '7,8,179,254,259', '-n',
+        devices_list = subprocess.check_output(['lsblk', '-d', '-I', '7,8,179,202,254,259', '-n',
                                                 '--output', 'NAME,SIZE,MODEL'],
                                                stderr=open(os.devnull, 'w'))
         return Device.wrap_devices_from_list(devices_list)
@@ -21,7 +21,7 @@ class Device(object):
     @staticmethod
     def refresh_devices_bytes():
         devices_list = subprocess.check_output(['lsblk', '-d', '--bytes', '-I',
-                                                '7,8,179,254,259', '-n', '--output', 'NAME,SIZE,MODEL'],
+                                                '7,8,179,202,254,259', '-n', '--output', 'NAME,SIZE,MODEL'],
                                                stderr=open(os.devnull, 'w'))
         return Device.wrap_devices_from_list(devices_list)
 


### PR DESCRIPTION
Add "Xen Virtual Block Device" major device number into "device.py" to allow install on XenServer/XCP-ng hypervisor