### PR TITLE
Update changing-the-locale.md

### DIFF
--- a/docs/photon_admin/changing-the-locale.md
+++ b/docs/photon_admin/changing-the-locale.md
@@ -9,7 +9,13 @@ To find the locale, run the the `localectl` command:
        VC Keymap: n/a
       X11 Layout: n/a
 
-To change the locale, choose the languages that you want from `/usr/share/locale/locale.alias`, add them to `/etc/locale-gen.conf`, and then regenerate the locale list by running the following command as root: 
+To change the locale, 
+
+first install glibc-i18n:
+
+    tdnf install glibc-i18n
+
+ then choose the languages that you want from `/usr/share/locale/locale.alias`, add them to `/etc/locale-gen.conf`, and then regenerate the locale list by running the following command as root: 
 
     locale-gen.sh
 


### PR DESCRIPTION
localegen fails if glibc-i18n is not installed. The Photon 3.0 OVA requires this manual installation of glibc-i18n - localegen.sh fails otherwise:

```
root@photon-machine [ ~ ]# locale-gen.sh
Generating locales...
  en_US.ISO-8859-1...failed to set locale!
[error] cannot open locale definition file `en_GB': No such file or directory
```

See old issue https://github.com/vmware/photon/issues/612 for further corroboration.