### PR TITLE
fixing KUBELET_API_SERVER example in v3 and v4 docs

### DIFF
--- a/content/en/docs-v3/user-guide/kubernetes-on-photon-os/running-kubernetes-on-photon-os/configure-kubernetes-on-node.md
+++ b/content/en/docs-v3/user-guide/kubernetes-on-photon-os/running-kubernetes-on-photon-os/configure-kubernetes-on-node.md
@@ -18,7 +18,7 @@ Perform the following steps to configure the kubelet on the node:
     KUBELET_HOSTNAME="--hostname_override=photon-node"
     
     # location of the api-server
-    KUBELET_API_SERVER="--api_servers=http://kubeconfig=/etc/kubernetes/kubeconfig"
+    KUBELET_API_SERVER="--kubeconfig=/etc/kubernetes/kubeconfig"
     
     # Add your own
     #KUBELET_ARGS=""

--- a/content/en/docs/user-guide/kubernetes-on-photon-os/running-kubernetes-on-photon-os/configure-kubernetes-on-node.md
+++ b/content/en/docs/user-guide/kubernetes-on-photon-os/running-kubernetes-on-photon-os/configure-kubernetes-on-node.md
@@ -18,7 +18,7 @@ Perform the following steps to configure the kubelet on the node:
     KUBELET_HOSTNAME="--hostname_override=photon-node"
     
     # location of the api-server
-    KUBELET_API_SERVER="--api_servers=http://photon-master:8080"
+    KUBELET_API_SERVER="--kubeconfig=/etc/kubernetes/kubeconfig"
     
     # Add your own
     #KUBELET_ARGS=""


### PR DESCRIPTION
content/en/docs-v3/user-guide/kubernetes-on-photon-os/running-kubernetes-on-photon-os/configure-kubernetes-on-node.md