### PR TITLE
Change 10-kubeadm.conf file permission to 644

### DIFF
--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -113,7 +113,7 @@ install -p -m 755 -t %{buildroot}/opt/vmware/kubernetes/windows/%{archname}/ _ou
 install -vdm644 %{buildroot}/etc/systemd/system/kubelet.service.d
 install -p -m 755 -t %{buildroot}%{_bindir} _output/local/bin/linux/%{archname}/kubeadm
 install -p -m 755 -t %{buildroot}/etc/systemd/system %{SOURCE2}
-install -p -m 755 -t %{buildroot}/etc/systemd/system/kubelet.service.d %{SOURCE3}
+install -p -m 644 -t %{buildroot}/etc/systemd/system/kubelet.service.d %{SOURCE3}
 sed -i '/KUBELET_CGROUP_ARGS=--cgroup-driver=systemd/d' %{buildroot}/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 cd ..


### PR DESCRIPTION
10-kubeadm.conf file permissions should be set to 644 or more restrictive to satisfy CIS benchmark requirements.

Co-authored-by: Rishabh Jain <rjain3@vmware.com>
Co-authored-by: Sam Mirza <mirzasa@vmware.com>