### PR TITLE
Change 10-kubeadm.conf file permission to 644

### DIFF
--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Kubernetes cluster management
 Name:           kubernetes
 Version:        1.19.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/kubernetes/kubernetes/archive/v%{version}.tar.gz
 Source0:        kubernetes-%{version}.tar.gz
@@ -113,7 +113,7 @@ install -p -m 755 -t %{buildroot}/opt/vmware/kubernetes/windows/%{archname}/ _ou
 install -vdm644 %{buildroot}/etc/systemd/system/kubelet.service.d
 install -p -m 755 -t %{buildroot}%{_bindir} _output/local/bin/linux/%{archname}/kubeadm
 install -p -m 755 -t %{buildroot}/etc/systemd/system %{SOURCE2}
-install -p -m 755 -t %{buildroot}/etc/systemd/system/kubelet.service.d %{SOURCE3}
+install -p -m 644 -t %{buildroot}/etc/systemd/system/kubelet.service.d %{SOURCE3}
 sed -i '/KUBELET_CGROUP_ARGS=--cgroup-driver=systemd/d' %{buildroot}/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 cd ..
@@ -231,6 +231,8 @@ fi
 %endif
 
 %changelog
+*   Tue Jun 22 2021 Rishabh Jain <rjain3@vmware.com> 1.19.10-3
+-   Change 10-kubeadm.conf file permission to 644
 *   Fri Jun 11 2021 Piyush Gupta<gpiyush@vmware.com> 1.19.10-2
 -   Bump up version to compile with new go
 *   Tue May 11 2021 Prashant S Chauhan <psinghchauha@vmware.com> 1.19.10-1


### PR DESCRIPTION
10-kubeadm.conf file permissions should be set to 644 or more restrictive to satisfy CIS benchmark requirements.

Co-authored-by: Sam Mirza <mirzasa@vmware.com>