### PR TITLE
DKMS version modified

### DIFF
--- a/SPECS/dkms/dkms.spec
+++ b/SPECS/dkms/dkms.spec
@@ -1,7 +1,7 @@
 %global commit 7c3e7c52a3816c82fc8a0ef4bed9cebedc9dd02d
 Summary:        Dynamic Kernel Module Support
 Name:           dkms
-Version:        2.8.4
+Version:        3.0.3
 Release:        1%{?dist}
 License:        GPLv2+
 URL:            http://linux.dell.com/dkms/


### PR DESCRIPTION
Signed-off-by: Prasanthi Vegesana <pvegesana@vmware.com>

While working with IPV4/IPV6 translation project found that DKMS package of version 2.8.4 on PhotonOS was broken.

When we try sudo dkms install jool/4.1.5.git.v4.1.5.16.g88339465 and sudo dkms uninstall jool/4.1.5.git.v4.1.5.16.g88339465, the commands silently succeeding without installing kernel modules(.ko files).

But the same commands got succeeded with 3.0.3 version.

So have updated spec file with the new version.

**2.8.4 version installation**:- ---> not installed

zsh 7 [65] % sudo tdnf install dkms

Installing:
dkms                                                                         noarch                                 2.8.2-2.ph4                                        photon-updates                                    194.54k 199214

Total installed size: 194.54k 199214
Is this ok [y/N]: y

Downloading:
dkms                                     67029   100%
Testing transaction
Running transaction
Installing/Updating: dkms-2.8.2-2.ph4.noarch

Complete!
[Thu 22/01/13 21:56 UTC][pts/35][x86_64/linux-gnu/5.10.78-4.ph4-esx][5.8]
<vmware@dev:~>
zsh 8 % sudo dkms install jool/4.1.5.git.v4.1.5.16.g88339465
[Thu 22/01/13 21:56 UTC][pts/35][x86_64/linux-gnu/5.10.78-4.ph4-esx][5.8]
<vmware@dev:~>

 //////////////////////////////////////////////////////////////////////////////////////////////////

**3.0.3 dkms version:** ---> successfully installed

zsh 12  (git)-[master]-% dkms --version
dkms-3.0.3
[Thu 22/01/13 21:58 UTC][pts/35][x86_64/linux-gnu/5.10.78-4.ph4-esx][5.8]
<vmware@dev:~/dkms>
zsh 13  (git)-[master]-% sudo dkms install jool/4.1.5.git.v4.1.5.16.g88339465

Building module:
cleaning build area...
make -j8 KERNELRELEASE=5.10.78-4.ph4-esx -C /lib/modules/5.10.78-4.ph4-esx/build M=/var/lib/dkms/jool/4.1.5.git.v4.1.5.16.g88339465/build/src/mod/common modules && make -C /lib/modules/5.10.78-4.ph4-esx/build M=/var/lib/dkms/jool/4.1.5.git.v4.1.5.16.g88339465/build/src/mod/nat64 modules && make -C /lib/modules/5.10.78-4.ph4-esx/build M=/var/lib/dkms/jool/4.1.5.git.v4.1.5.16.g88339465/build/src/mod/siit modules......
cleaning build area...

jool_common.ko.xz:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.78-4.ph4-esx/extra//

jool.ko.xz:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.78-4.ph4-esx/extra//

jool_siit.ko.xz:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.78-4.ph4-esx/extra//
depmod...
