### PR TITLE
Fix broken link to tdnf docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Photon OS&trade; is an open source Linux container host optimized for cloud-nati
 
 - **Support for containers:** Photon OS includes the Docker daemon and works with container orchestration frameworks, such as Mesos and Kubernetes.
 
-- **Efficient lifecycle management:** Photon OS is easy to manage, patch, and update, using the [tdnf package manager](https://github.com/vmware/photon/blob/master/docs/photon-admin-guide.md#tiny-dnf-for-package-management) and the [Photon Management Daemon (pmd)](https://github.com/vmware/pmd).
+- **Efficient lifecycle management:** Photon OS is easy to manage, patch, and update, using the [tdnf package manager](https://github.com/vmware/photon/blob/master/docs/photon_admin/package_management.md) and the [Photon Management Daemon (pmd)](https://github.com/vmware/pmd).
 
 - **Security hardened:** Photon OS provides secure and up-to-date kernel and other packages, and its policies are designed to govern the system securely.
 

--- a/docs/photon_admin/creating-a-stand-alone-photon-machine-with-cloud-init.md
+++ b/docs/photon_admin/creating-a-stand-alone-photon-machine-with-cloud-init.md
@@ -29,7 +29,7 @@ Cloud-init can customize a Photon OS virtual machine by using the `nocloud` data
 
     The ISO now appears in the current directory: 
 
-        ```
+    ```
     steve@ubuntu:~$ ls
 	meta-data seed.iso user-data
     ```


### PR DESCRIPTION
The current link to 'the tdnf package manager' is broken.