### PR TITLE
Update PhotonOS-versions.md

### DIFF
--- a/docs/PhotonOS-versions.md
+++ b/docs/PhotonOS-versions.md
@@ -4,4 +4,4 @@ Photon OS consists of a minimal version and a full version.
 
 The minimal version of Photon OS is lightweight container host runtime environment that is suited to managing and hosting containers. The minimal version contains just enough packaging and functionality to manage and modify containers while remaining a fast runtime environment. The minimal version is ready to work with appliances. 
 
-The Developer version of Photon OS includes additional packages to help you customize the system and create containerized applications. For running containers, the developer version is excessive. The devloper version helps you create, develop, test, and package an application that runs a container. 
+The developer version of Photon OS includes additional packages to help you customize the system and create containerized applications. For running containers, the developer version is excessive. The developer version helps you create, develop, test, and package an application that runs a container. 


### PR DESCRIPTION
There should be consistency in the capitalization between "minimal" and "developer" 
Spelling fix for "developer"