### PR TITLE
Update working-with-kickstart.md

### DIFF
--- a/content/en/docs/user-guide/working-with-kickstart.md
+++ b/content/en/docs/user-guide/working-with-kickstart.md
@@ -487,17 +487,10 @@ Now add a new item to the installation menu by modifying `isolinux/menu.cfg`:
 ```console
 cat >> isolinux/menu.cfg << EOF
 label my_unattended
-	menu label ^My Unattended Install
-	menu default
-	kernel vmlinuz
-	append initrd=initrd.img root=/dev/ram0 loglevel=3 photon.media=cdrom
-EOF
-cat >> isolinux/menu.cfg << EOF
-label my_unattended
     menu label ^My Unattended Install
     menu default
     kernel vmlinuz
-    append initrd=initrd.img root=/dev/ram0 ks=my_ks.cfg loglevel=3 photon.media=cdrom
+    append initrd=initrd.img root=/dev/ram0 ks=<ks_path>/my_ks.cfg loglevel=3 photon.media=cdrom
 EOF
 
 cat >> boot/grub2/grub.cfg << EOF
@@ -511,7 +504,7 @@ terminal_output gfxterm
 probe -s photondisk -u ($root)
 
 menuentry "Install" {
-    linux /isolinux/vmlinuz root=/dev/ram0 ks=my_ks.cfg loglevel=3 photon.media=UUID=$photondisk
+    linux /isolinux/vmlinuz root=/dev/ram0 ks=<ks_path>/my_ks.cfg loglevel=3 photon.media=UUID=$photondisk
     initrd /isolinux/initrd.img
 }
 EOF 

--- a/content/en/docs/user-guide/working-with-kickstart.md
+++ b/content/en/docs/user-guide/working-with-kickstart.md
@@ -492,6 +492,30 @@ label my_unattended
 	kernel vmlinuz
 	append initrd=initrd.img root=/dev/ram0 loglevel=3 photon.media=cdrom
 EOF
+cat >> isolinux/menu.cfg << EOF
+label my_unattended
+    menu label ^My Unattended Install
+    menu default
+    kernel vmlinuz
+    append initrd=initrd.img root=/dev/ram0 ks=my_ks.cfg loglevel=3 photon.media=cdrom
+EOF
+
+cat >> boot/grub2/grub.cfg << EOF
+set default=0
+set timeout=3
+loadfont ascii
+set gfxmode="1024x768"
+gfxpayload=keep
+set theme=/boot/grub2/themes/photon/theme.txt
+terminal_output gfxterm
+probe -s photondisk -u ($root)
+
+menuentry "Install" {
+    linux /isolinux/vmlinuz root=/dev/ram0 ks=my_ks.cfg loglevel=3 photon.media=UUID=$photondisk
+    initrd /isolinux/initrd.img
+}
+EOF 
+
 ```
 
 **Note:** You can specify any mount media through which you want to boot Photon OS. To specify the mount media, specify the path of the mount media device in the `photon.media` field. You can specify the path as shown in the following syntax:


### PR DESCRIPTION
Only adding bootmode in kickstart file doesn't work for Photon autoinstall in EFI mode, which also requires to update in boot/grub2/grub.cfg with the ks= option