### PR TITLE
Update root-account-sudo-and-su-commands.md

### DIFF
--- a/content/en/docs-v5/troubleshooting-guide/introduction/root-account-sudo-and-su-commands.md
+++ b/content/en/docs-v5/troubleshooting-guide/introduction/root-account-sudo-and-su-commands.md
@@ -3,4 +3,4 @@ title:  The Root Account and the `sudo` and `su` Commands
 weight: 2
 ---
 
-The *Troubleshooting Guide* assumes that you are logged in to Photon OS with the root account and running commands as root. The `sudo` program comes with the full version of Photon OS. On the minimal version, you must install `sudo` with tdnf if you want to use it. As an alternative to installing `sudo` on the minimal version, you can switch users as needed with the `su` command to run commands that require root privileges.
+The *Troubleshooting Guide* assumes that you are logged in to Photon OS with the root account and running commands as root. The `sudo` program comes with the full version of Photon OS. On the minimal version, you must install `sudo` with tdnf if you want to use it. As an alternative to installing `sudo` on the minimal version, you can switch users as needed with the `su` command to run commands that require root privileges. 

--- a/content/en/docs-v5/troubleshooting-guide/introduction/root-account-sudo-and-su-commands.md
+++ b/content/en/docs-v5/troubleshooting-guide/introduction/root-account-sudo-and-su-commands.md
@@ -3,4 +3,4 @@ title:  The Root Account and the `sudo` and `su` Commands
 weight: 2
 ---
 
-The *Troubleshooting Guide* assumes that you are logged in to Photon OS with the root account and running commands as root. The `sudo` program comes with the full version of Photon OS. On the minimal version, you must install `sudo` with tdnf if you want to use it. As an alternative to installing `sudo` on the minimal version, you can switch users as needed with the `su` command to run commands that require root privileges. 
+The *Troubleshooting Guide* assumes that you are logged in to Photon OS with the root account and running commands as root. The `sudo` program comes with the minimal and full version of Photon OS. As an alternative to use `sudo` on the minimal version, you can switch users as needed with the `su` command to run commands that require root privileges. In this case, the package can be removed with `tdnf remove sudo` if you don't want to use it.


### PR DESCRIPTION
For at least Ph5 minimal RC (generic) and Ph5 Full ISO (minimal installation, generic), `sudo` is preinstalled. sudo 1.9.12p1-2.ph5
Is this still correct?