### PR TITLE
Updated the dotnet version, added aspnet core spec

### DIFF
--- a/SPECS/dotnet-aspnet/dotnet-aspnet.spec
+++ b/SPECS/dotnet-aspnet/dotnet-aspnet.spec
@@ -1,0 +1,64 @@
+%global debug_package %{nil}
+
+Summary:        Microsoft ASP.NET Core Runtime
+Name:           aspnetcore-runtime
+Version:        7.0.5
+Release:        1%{?dist}
+Vendor:         VMware, Inc.
+Distribution:   Photon
+License:        MIT
+Url:            https://github.com/dotnet/aspnetcore
+Group:          Development/Tools
+
+# Download source tarball from the links provided in:
+# https://github.com/dotnet/core/tree/main/release-notes
+#
+# For example:
+# https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.0/6.0.0.md
+# https://download.visualstudio.microsoft.com/download/pr/0ce1c34f-0d9e-4d9b-964e-da676c8e605a/7a6c353b36477fa84f85b2821f2350c2/dotnet-runtime-6.0.0-linux-x64.tar.gz
+Source0: %{name}-%{version}-linux-x64.tar.gz
+%define sha512 %{name}=859d48d0f29e014d56e89161d8001f75b3b0b03ee04f86641066570cfbe267b06798232500a86fd7bc31edf022097278dfeb496874778fead4476863aa994928
+
+BuildArch: x86_64
+
+BuildRequires: lttng-ust-devel >= 2.13.4-2
+
+Requires: curl
+Requires: libunwind
+Requires: krb5
+Requires: lttng-ust >= 2.13.4-2
+Requires: libstdc++
+
+%description
+ASP.NET Core is an open-source and cross-platform framework for building modern
+cloud-based internet-connected applications, such as web apps, IoT apps, and mobile backends.
+
+%prep
+%autosetup -p1 -c %{name}-%{version} -p1
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_libdir}/dotnet \
+         %{buildroot}%{_docdir}/%{name}-%{version} \
+         %{buildroot}%{_bindir}
+
+cp -pr * %{buildroot}%{_libdir}/dotnet
+ln -sfrv %{buildroot}%{_libdir}/dotnet/dotnet %{buildroot}%{_bindir}/dotnet
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%clean
+rm -rf %{buildroot}/*
+
+%files
+%defattr(-,root,root,0755)
+%exclude %dir %{_libdir}/debug
+%{_docdir}/*
+%{_bindir}/dotnet
+%{_libdir}/*
+
+%changelog
+* Thu Jun 01 2023 Raymond Welch <rwelch@vmware.com> 7.0.5-1
+- Initial build for photon

--- a/SPECS/dotnet-runtime/dotnet-runtime.spec
+++ b/SPECS/dotnet-runtime/dotnet-runtime.spec
@@ -2,7 +2,7 @@
 
 Summary:        Microsoft .NET Core Runtime
 Name:           dotnet-runtime
-Version:        7.0.2
+Version:        7.0.5
 Release:        1%{?dist}
 Vendor:         VMware, Inc.
 Distribution:   Photon
@@ -17,7 +17,7 @@ Group:          Development/Tools
 # https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.0/6.0.0.md
 # https://download.visualstudio.microsoft.com/download/pr/0ce1c34f-0d9e-4d9b-964e-da676c8e605a/7a6c353b36477fa84f85b2821f2350c2/dotnet-runtime-6.0.0-linux-x64.tar.gz
 Source0: %{name}-%{version}-linux-x64.tar.gz
-%define sha512 %{name}=56f7f471052b955968b9a4caa27299ac003e0347ae80e8ef23de87d28a2707bdf7ceb70467cc3e9f0c80928a779841dd7e1392ed6b06e66a7a9cda696d5c0a1e
+%define sha512 %{name}=68014bdbf55bf455f59549c7d9d61ccc051e09fe74a975ca6b46d3269278d77c9cd167ba05760aef8ab413df4212f4f5cebdd1533779b49caf517eb4ec50cce5
 
 BuildArch: x86_64
 
@@ -27,6 +27,7 @@ Requires: curl
 Requires: libunwind
 Requires: krb5
 Requires: lttng-ust >= 2.13.4-2
+Requires: libstdc++
 
 %description
 .NET Core is a development platform that you can use to build command-line
@@ -59,6 +60,8 @@ rm -rf %{buildroot}/*
 %{_libdir}/*
 
 %changelog
+* Thu Jun 01 2023 Raymond Welch <rwelch@vmware.com> 7.0.5-1
+- Upgrade to v7.0.5
 * Sat Feb 11 2023 Shreenidhi Shedi <sshedi@vmware.com> 7.0.2-1
 - Upgrade to v7.0.2
 * Wed Oct 05 2022 Shreenidhi Shedi <sshedi@vmware.com> 7.0.0-rc1

--- a/SPECS/dotnet-sdk/dotnet-sdk.spec
+++ b/SPECS/dotnet-sdk/dotnet-sdk.spec
@@ -2,8 +2,8 @@
 
 Summary:        Microsoft .NET Core SDK
 Name:           dotnet-sdk
-Version:        7.0.102
-Release:        2%{?dist}
+Version:        7.0.302
+Release:        1%{?dist}
 Vendor:         VMware, Inc.
 Distribution:   Photon
 License:        MIT
@@ -17,12 +17,18 @@ Group:          Development/Tools
 # https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.0/6.0.0.md
 # https://download.visualstudio.microsoft.com/download/pr/17b6759f-1af0-41bc-ab12-209ba0377779/e8d02195dbf1434b940e0f05ae086453/dotnet-sdk-6.0.100-linux-x64.tar.gz
 Source0: %{name}-%{version}-linux-x64.tar.gz
-%define sha512 %{name}=7667aae20a9e50d31d1fc004cdc5cb033d2682d3aa793dde28fa2869de5ac9114e8215a87447eb734e87073cfe9496c1c9b940133567f12b3a7dea31a813967f
+%define sha512 %{name}=9387bd804ed980ba1bc33093598ddbafa3a761e07d28916c94442cc329533d78a03bfc59d3066a1a861244302414e7e658b4e721b5bc825f623f8f908e748b7e
 
 BuildArch: x86_64
 
-Requires: dotnet-runtime >= 7.0.2
+BuildRequires: lttng-ust-devel >= 2.13.4-2
+
+Requires: curl
+Requires: libunwind
+Requires: krb5
+Requires: lttng-ust >= 2.13.4-2
 Requires: icu >= 70.1
+Requires: libstdc++
 
 %description
 .NET Core is a development platform that you can use to build command-line
@@ -43,6 +49,8 @@ cp -pr sdk/%{version} %{buildroot}%{_libdir}/dotnet/sdk
 %{_libdir}/*
 
 %changelog
+* Thu Jun 01 2023 Raymond Welch <rwelch@vmware.com> 7.0.302-1
+- Upgrade to v7.0.302, removed the dotnet-runtime dependency, sdk installs the dotnet runtime.
 * Sun Feb 12 2023 Shreenidhi Shedi <sshedi@vmware.com> 7.0.102-2
 - Bump version as a part of icu upgrade
 * Sat Feb 11 2023 Shreenidhi Shedi <sshedi@vmware.com> 7.0.102-1


### PR DESCRIPTION
Updated the dotnet versions for the sdk and runtime, added an aspnet core spec file, removed the dependency sdk had on the runtime spec as the sdk will install the runtime, aspnet, and sdk components. Also added libstdc++ as a requirement, when setting up dotnet on Photon v5 manually it was required.