### PR TITLE
Fixed critical typo in sysctl.d config

### DIFF
--- a/content/en/docs-v5/user-guide/kubernetes-on-photon-os/kubernetes-kubeadm-cluster-on-photon/configure-master-node.md
+++ b/content/en/docs-v5/user-guide/kubernetes-on-photon-os/kubernetes-kubeadm-cluster-on-photon/configure-master-node.md
@@ -74,7 +74,7 @@ cat /etc/sysctl.d/kubernetes.conf
 net.ipv4.ip_forward = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
-net/bridge/bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-arptables = 1
 ```   
 
 Apply the new `sysctl` setttings as follows:

--- a/content/en/docs-v5/user-guide/kubernetes-on-photon-os/kubernetes-kubeadm-cluster-on-photon/configure-worker-node-on-kubernetes.md
+++ b/content/en/docs-v5/user-guide/kubernetes-on-photon-os/kubernetes-kubeadm-cluster-on-photon/configure-worker-node-on-kubernetes.md
@@ -74,7 +74,7 @@ cat /etc/sysctl.d/kubernetes.conf
 net.ipv4.ip_forward = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
-net/bridge/bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-arptables = 1
 ```   
 
 Apply the new `sysctl` settings as follows:


### PR DESCRIPTION
typo prevents /etc/systctl.d/kubernetes.yaml to be loaded by sysctl --system and therefore breaks the cluster networking.
