### PR TITLE
Added NoneType error check for convert_to_list

### DIFF
--- a/SPECS/ansible/tdnf.py
+++ b/SPECS/ansible/tdnf.py
@@ -289,12 +289,14 @@ def convert_to_list(input_list):
     """Convert nested list into flat list"""
     flat_list = []
 
-    for sublist in input_list:
-        if not isinstance(sublist, list):
-            flat_list.append(sublist)
-            continue
-        for item in sublist:
-            flat_list.append(item)
+    if input_list is not None:
+      for sublist in input_list:
+          if not isinstance(sublist, list):
+              flat_list.append(sublist)
+              continue
+          if sublist is not None:
+            for item in sublist:
+                flat_list.append(item)
 
     return flat_list
 


### PR DESCRIPTION
Adding NoneType check to fix the issue #1508. The convert_to_list is not checking for NoneType which occurs when someone is using the tdnf module to perform a update_cache or upgrade command, as this does not populate the name argument which is used to create the pkglist.