### PR TITLE
[SPEC] update coredns version to v1.11.4

### DIFF
--- a/SPECS/coredns/coredns.spec
+++ b/SPECS/coredns/coredns.spec
@@ -7,7 +7,7 @@
 
 Summary:        CoreDNS
 Name:           coredns
-Version:        1.11.1
+Version:        1.11.4
 Release:        2%{?dist}
 License:        Apache License 2.0
 URL:            https://github.com/%{name}/%{name}
@@ -16,7 +16,7 @@ Vendor:         VMware, Inc.
 Distribution:   Photon
 
 Source0: https://github.com/coredns/coredns/archive/refs/tags/%{name}-%{version}.tar.gz
-%define sha512  %{name}=f8752811e9e7913311f47ae13f35c755ac86ea240572be1c1dabc1712b6c42380c60ac385fa9573c77d6fcf4c144df2bc00574f18e8d7b70da21ed8ae4fb87cd
+%define sha512  %{name}=90506926736152958d6ec154734a6cce689406aea9eed7d68e868fa48361b0fb5c899d445f52e13a5401b91683c8ed7715c80617efaabdd7b5d9dde6ca634984
 
 BuildRequires: go
 BuildRequires: git
@@ -60,6 +60,8 @@ rm -rf %{buildroot}/*
 %{_bindir}/%{name}
 
 %changelog
+* Fri Jan 17 2024 Humble Chirammal <humble.devassy-c@broadcom.com> 1.11.4
+- version upgrade
 * Tue Nov 21 2023 Piyush Gupta <gpiyush@vmware.com> 1.11.1-2
 - Bump up version to compile with new go
 * Fri Nov 03 2023 Nitesh Kumar <kunitesh@vmware.com> 1.11.1-1


### PR DESCRIPTION
Considering there are many important bug fixes and CVE fixes available in 1.11.4, upgrading to v1.11.4