### PR TITLE
[SPEC] Update Boost artifact URL to archives.boost.io

### DIFF
--- a/SPECS/boost/boost.spec
+++ b/SPECS/boost/boost.spec
@@ -2,7 +2,7 @@
 Summary:        Boost
 Name:           boost
 Version:        1.80.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Boost Software License V1
 URL:            http://www.boost.org
 Group:          System Environment/Security
@@ -66,6 +66,8 @@ rm -rf %{buildroot}/*
 %{_libdir}/libboost_*.a
 
 %changelog
+* Tue Jan 21 2024 Tom Plant <tom@tplant.com.au> 1.80.0-1
+- Update download URL
 * Fri Aug 19 2022 Ajay Kaher <akaher@vmware.com> 1.80.0-1
 - Version update
 * Mon Apr 12 2021 Gerrit Photon <photon-checkins@vmware.com> 1.76.0-1

--- a/SPECS/boost/boost.spec
+++ b/SPECS/boost/boost.spec
@@ -8,7 +8,7 @@ URL:            http://www.boost.org
 Group:          System Environment/Security
 Vendor:         VMware, Inc.
 Distribution:   Photon
-Source0:        https://boostorg.jfrog.io/artifactory/main/release/%{version}/source/boost_%{main_version}.tar.bz2
+Source0:        https://archives.boost.io/release/%{version}/source/boost_%{main_version}.tar.bz2
 %define sha512  boost=829a95b463473d69ff79ea41799c68429bb79d3b2321fbdb71df079af237ab01de9ad7e9612d8783d925730acada010068d2d1aa856c34244ee5c0ece16f208f
 
 BuildRequires:	bzip2-devel


### PR DESCRIPTION
This pull request updates Boost artifact URL(s) from `boostorg.jfrog.io/artifactory/main/release` to `archives.boost.io/release`.

Boost have changed to a new download provider, and the old JFrog URLs are no longer available: https://github.com/boostorg/boost/issues/996