### PR TITLE
[SPEC] Update containerd 1.6.38

### DIFF
--- a/SPECS/containerd/config.yaml
+++ b/SPECS/containerd/config.yaml
@@ -1,6 +1,6 @@
 sources:
-- archive: containerd-1.6.21.tar.gz
-  archive_sha512sum: a94ed8b8b9e153c9dc370228b659fcba1b03b3c47c8b5fcb001bb1b4b158ea048159f5d8d8c5294e7da3444edd76fbd903d7b7faa84e3382807a583d757325e1
+- archive: containerd-1.6.38.tar.gz
+  archive_sha512sum: c908e1bb8167ce44d801eeeedb9190f5429de66663b6a3989c9626334af2c79162830de58f24dc534b116cf74f1388945d242c74f9b4dc858b34cd4399e45fbb
   skip_validation: true
   spdx:
     package:

--- a/SPECS/containerd/containerd-config.toml
+++ b/SPECS/containerd/containerd-config.toml
@@ -12,7 +12,7 @@ version = 2
 #  gid = 0
 
 [plugins."io.containerd.grpc.v1.cri"]
-enable_selinux = true
+  enable_selinux = true
 
 #[debug]
 #  address = "/run/containerd/debug.sock"

--- a/SPECS/containerd/containerd.spec
+++ b/SPECS/containerd/containerd.spec
@@ -4,17 +4,17 @@
 
 Summary:        Containerd
 Name:           containerd
-Version:        1.6.21
-Release:        13%{?dist}
+Version:        1.6.38
+Release:        1%{?dist}
 URL:            https://containerd.io/docs
 Group:          Applications/File
 Vendor:         VMware, Inc.
 Distribution:   Photon
 
-Source0: https://github.com/containerd/containerd/archive/%{name}-%{version}.tar.gz
+Source0: https://github.com/containerd/containerd/archive/refs/tags/v%{version}.tar.gz
 
 # Must be in sync with package version
-%define CONTAINERD_GITCOMMIT 3dce8eb055cbb6872793272b4f20ed16117344f8
+%define CONTAINERD_GITCOMMIT cf158e884cfe4812a6c371b59e4ea9bc4c46e51a
 
 Source1: %{name}-config.toml
 Source2: disable-%{name}-by-default.preset
@@ -29,8 +29,7 @@ BuildRequires: btrfs-progs
 BuildRequires: btrfs-progs-devel
 BuildRequires: libseccomp
 BuildRequires: libseccomp-devel
-# Upstream is unhappy with 1.14. 1.13 or 1.15+ is OK
-BuildRequires: go >= 1.16
+BuildRequires: go >= 1.23
 BuildRequires: go-md2man
 BuildRequires: systemd-devel
 
@@ -136,6 +135,8 @@ make %{?_smp_mflags} integration
 %{_mandir}/man8/*
 
 %changelog
+* Thu May 08 2025 Akhil Mohan <akhil.mohan@broadcom.com> 1.6.38-1
+- Upgrade to 1.6.38
 * Thu Dec 12 2024 HarinadhD <harinadh.dommaraju@broadcom.com> 1.6.21-13
 - Release bump for SRP compliance
 * Thu Sep 19 2024 Mukul Sikka <mukul.sikka@broadcom.com> 1.6.21-12


### PR DESCRIPTION
- update containerd version to v1.6.38 (latest in the 1.6 series)
- update minimum go version for building to 1.23
- fix indentation error in containerd config