### PR TITLE
Documentation fixes - 2025-11-30T23-16-19.810324

### DIFF
--- a/content/en/docs-v3/installation-guide/install-photon-on-dell-gateway/installing-photon-os-on-dell-300X.md
+++ b/content/en/docs-v3/installation-guide/install-photon-on-dell-gateway/installing-photon-os-on-dell-300X.md
@@ -21,7 +21,7 @@ You can install Photon OS 3.0 on Dell Gateway 300X. You can download Photon OS a
     
     For example, run the following command on macOS:
 
-    `hdiutil mount photon-3.0-ec12f2c.iso` 
+    `hdiutil mount photon-3.0-ec12f2c.iso ` 
 
     Use a similar command in other operating systems.
 
@@ -36,24 +36,24 @@ mkdir -p /tmp/photonUsb
 
     where, `/Volumes/PHOTON_<timestamp>` is the directory where the ISO is mounted with the command in the step above.
 
-1. Edit the `grub.cfg` file to use the kickstart config file:
+1. Edit the ` grub.cfg ` file to use the kickstart config file:
     
-    `cd /tmp/photonUsb`
+    ` cd /tmp/photonUsb `
 
-    Add the below parameters to the linux cmd line in `boot/grub2/grub.cfg`
+    Add the below parameters to the linux cmd line in ` boot/grub2/grub.cfg `
    
     ```
     linux /isolinux/vmlinuz root=/dev/ram0 loglevel=3 photon.media=UUID=$photondisk ks=cdrom:/isolinux/sample_ks.cfg console=ttyS0,115200n8
     ```
 
-1. Edit the `isolinux/sample_ks.cfg`  as follows:
+1. Edit the ` isolinux/sample_ks.cfg `  as follows:
 
     - Change `"disk": "/dev/sda”,` to **`"disk": "/dev/mmcblk0",`**
     - Change `"echo \"Hello World\" > /etc/postinstall"` to **`"sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config"`**
     
-1. Format the pen drive with FAT-32 and copy all the contents of `/tmp/photonUsb` to the pen drive. 
+1. Format the pen drive with FAT-32 and copy all the contents of `/tmp/photonUsb ` to the pen drive. 
 
-1. Create a `UsbInvocationScript.txt` file in the root of the pen drive with below content:
+1. Create a ` UsbInvocationScript.txt ` file in the root of the pen drive with below content:
 
     ```
 usb_disable_secure_boot noreset;
@@ -66,7 +66,7 @@ usb_one_time_boot usb nolog;
 
 1. After the installation is complete, insert a network cable into the ethernet port and find the IP address corresponding to the MAC address of the Dell Gateway 3000X ethernet port through the DHCP Server or a network analyzer. The MAC address is available on the Dell Gateway 3000X.
 
-1. You can then use `ssh` to access the gateway with the above IP address.
+1. You can then use ` ssh` to access the gateway with the above IP address.
 
 
 

--- a/content/en/docs-v5/installation-guide/build-package-kernel-modules-using-script/package-to-provide-hello-world-kernel-module.md
+++ b/content/en/docs-v5/installation-guide/build-package-kernel-modules-using-script/package-to-provide-hello-world-kernel-module.md
@@ -3,18 +3,18 @@ title:  Hello World Kernel Module
 weight: 1
 ---
 
-This example shows how to build a package that provides a hello world kernel module. To build the package, you need to run the script with `hello-world.spec` as an argument, where `hello-world.spec` is the RPM specification file.
+This example shows how to build a package that provides a hello world kernel module. To build the package, you need to run the script with `hello-world.spec ` as an argument, where ` hello-world.spec ` is the RPM specification file.
 
 You can find the source file at the following location:  
 
-	https://github.com/vmware/photon/tree/<BRANCH>/tools/examples/build_spec/kernel_module_example/hello-world.tar.gz	
+	https://github.com/VMware/photon/tree/<BRANCH>/tools/examples/build_spec/kernel_module_example/hello-world.tar.gz	
 
 To generate the output in the spec-file folder, run the following command:
 
 
 	./photon/tools/scripts/build_spec.sh ./photon/tools/examples/build_spec/kernel_module_example/hello-world.spec
 
-The following are the contents of the `hello-world.spec` file:
+The following are the contents of the ` hello-world.spec ` file:
 
 ```
 %define linux_esx_ver 6.1.10
@@ -39,10 +39,10 @@ Example of building linux module for Photon OS
 %autosetup -n hello-world
 
 %build
-make -C `echo /usr/src/linux-headers-%{linux_esx_ver}*` M=`pwd` VERBOSE=1 modules %{?_smp_mflags}
+make -C ` echo /usr/src/linux-headers-%{linux_esx_ver}*` M=` pwd ` VERBOSE=1 modules %{?_smp_mflags}
 
 %install
-make -C `echo /usr/src/linux-headers-%{linux_esx_ver}*` M=`pwd` INSTALL_MOD_PATH=%{buildroot} modules_install %{?_smp_mflags}
+make -C ` echo /usr/src/linux-headers-%{linux_esx_ver}*` M=` pwd ` INSTALL_MOD_PATH=%{buildroot} modules_install %{?_smp_mflags}
 # fix permissins to generate non empty debuginfo
 find %{buildroot}/lib/modules -name '*.ko' -print0 | xargs -0 chmod u+x
 


### PR DESCRIPTION
# Documentation Analysis Report

**Generated:** 2025-11-30T23-16-19.810324
**Tool:** photonos-docs-lecturer.py v1.1
**Last Updated:** 2025-11-30T23:18:55.622840
**Pages analyzed:** 51
**Issues found:** 218
**Fixes applied:** 2
**LLM Provider:** None (deterministic fixes only)

## Files Fixed

- `content/en/docs-v3/installation-guide/install-photon-on-dell-gateway/installing-photon-os-on-dell-300X.md`: backtick spacing
- `content/en/docs-v5/installation-guide/build-package-kernel-modules-using-script/package-to-provide-hello-world-kernel-module.md`: VMware spelling, backtick spacing

## Issue Categories Detected and Fixed

### Deterministic Fixes (Applied Automatically)
- **VMware spelling**: Corrected incorrect spellings (vmware, Vmware, etc.) to VMware
- **Deprecated URLs**: Updated packages.vmware.com URLs to packages-prod.broadcom.com
- **Backtick spacing**: Fixed missing spaces before/after inline code
- **Shell prompts**: Removed shell prompt prefixes ($, #, ❯) from code blocks

### LLM-Assisted Fixes (Requires --llm flag)
- **Grammar/spelling errors**: Language and grammar corrections
- **Markdown artifacts**: Fixed unrendered markdown syntax
- **Mixed command/output**: Separated command and output into distinct code blocks

### Issues Reported (Manual Review Recommended)
- **Broken links**: Orphan URLs requiring manual verification
- **Broken images**: Missing or inaccessible image files
- **Unaligned images**: Images lacking proper CSS alignment
- **Indentation issues**: List item indentation problems

---
*This PR is updated incrementally as fixes are applied. Check the commit history for details.*
