### PR TITLE
Documentation fixes - 2025-12-01T00-42-24.427646

### DIFF
--- a/content/en/docs-v3/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md
+++ b/content/en/docs-v3/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md
@@ -1,9 +1,9 @@
----
+```console
 title:  Cloud-Init Overview
 weight: 1
 ---
 
-```cloud-init``` is a multi-distribution package that handles early initialization of a cloud instance.
+`cloud-init` is a multi-distribution package that handles early initialization of a cloud instance.
 
 In-depth documentation for cloud-init is available here:
 
@@ -12,7 +12,7 @@ In-depth documentation for cloud-init is available here:
 Supported installations
 =================
 
-Both the full version of and the minimal version of Photon OS support cloud-init. 
+Both the full version of and the minimal version of Photon OS support cloud-init.
 
 Supported capabilities
 =================
@@ -23,48 +23,48 @@ Photon OS supports the following cloud-init capabilities:
 * run commands: execute a list of commands with output to console.
 * configure ssh keys: add an entry to ~/.ssh/authorized_keys for the configured user.
 * install package: install additional packages on first boot.
-* configure networking: update /etc/hosts, hostname, etc.
+* configure networking: update /etc/hosts, hostname, `etc.`
 * write files: write arbitrary files to disk.
 * add yum repository: add a yum repository to /etc/yum.repos.d.
-* create groups and users: add groups and users to the system and set properties for them. 
+* create groups and users: add groups and users to the system and set properties for them.
 * run yum upgrade: upgrade all packages.
 * reboot: reboot or power off when done with cloud-init.
 
 
 Getting Started
 =================
-The Amazon Machine Image of Photon OS has an ```ec2 datasource``` turned on by default so an ```ec2``` configuration is accepted.
-However, for testing, the following methods provide ways to do ```cloud-init``` with a standalone instance of Photon OS.
+The Amazon Machine Image of Photon OS has an `ec2 datasource` turned on by default so an `ec2` configuration is accepted.
+However, for testing, the following methods provide ways to do `cloud-init` with a standalone instance of Photon OS.
 
 Using a Seed ISO
 ----------------
-This will be using the ```nocloud``` data source. In order to initialize the system in this way, an ISO file needs to be created with a meta-data file and an user-data file as shown below:
-```
-$ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-$ printf "#cloud-config\nhostname: testhost\n" > user-data
-$ genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
-```
+This will be using the `nocloud` data source. In order to initialize the system in this way, an ISO file needs to be created with a meta-data file and a user-data file as shown below:
+```console
+{ echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
+printf "#cloud-config\nhostname: testhost\n" > user-data
+genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
+```console
 
 Attach the `seed.iso` generated above to your machine and reboot for the init to take effect.
-In this case, the hostname is set to ```testhost```.
+In this case, the hostname is set to `testhost`.
 
 Using a Seed Disk File
 ----------------
 To init using local disk files, do the following:
-```
+```console
 mkdir /var/lib/cloud/seed/nocloud
 cd /var/lib/cloud/seed/nocloud
-$ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-$ printf "#cloud-config\nhostname: testhost\n" > user-data
-```
+{ echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
+printf "#cloud-config\nhostname: testhost\n" > user-data
+```console
 Reboot the machine and the hostname will be set to `testhost`.
 
 Frequencies
 -----------
 Cloud-init modules have predetermined frequencies. Based on the frequency setting, multiple runs will yield different results. For the scripts to always run, remove the `instances` directory before rebooting.
-```
+```console
 rm -rf /var/lib/cloud/instances
-```
+```console
 
 Module Frequency Info
 ------------------------------------
@@ -78,5 +78,6 @@ final_message         | Always
 resolv_conf           | Instance
 growpart              | Always
 update_etc_hosts      | Always
-power_state_change    | Instance
+`power_state_change`    | Instance
 phone_home            | Instance
+```

--- a/content/en/docs-v4/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md
+++ b/content/en/docs-v4/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md
@@ -39,10 +39,10 @@ However, for testing, the following methods provide ways to do ```cloud-init``` 
 Using a Seed ISO
 ----------------
 This will be using the ```nocloud``` data source. In order to initialize the system in this way, an ISO file needs to be created with a meta-data file and an user-data file as shown below:
-```
-$ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-$ printf "#cloud-config\nhostname: testhost\n" > user-data
-$ genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
+```console
+{ echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
+printf "#cloud-config\nhostname: testhost\n" > user-data
+genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
 ```
 
 Attach the `seed.iso` generated above to your machine and reboot for the init to take effect.
@@ -51,18 +51,18 @@ In this case, the hostname is set to ```testhost```.
 Using a Seed Disk File
 ----------------
 To init using local disk files, do the following:
-```
+```console
 mkdir /var/lib/cloud/seed/nocloud
 cd /var/lib/cloud/seed/nocloud
-$ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-$ printf "#cloud-config\nhostname: testhost\n" > user-data
+{ echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
+printf "#cloud-config\nhostname: testhost\n" > user-data
 ```
 Reboot the machine and the hostname will be set to `testhost`.
 
 Frequencies
 -----------
 Cloud-init modules have predetermined frequencies. Based on the frequency setting, multiple runs will yield different results. For the scripts to always run, remove the `instances` directory before rebooting.
-```
+```console
 rm -rf /var/lib/cloud/instances
 ```
 

--- a/content/en/docs-v5/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md
+++ b/content/en/docs-v5/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md
@@ -39,10 +39,10 @@ However, for testing, the following methods provide ways to do ```cloud-init``` 
 Using a Seed ISO
 ----------------
 This will be using the ```nocloud``` data source. In order to initialize the system in this way, an ISO file needs to be created with a meta-data file and an user-data file as shown below:
-```
-$ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-$ printf "#cloud-config\nhostname: testhost\n" > user-data
-$ genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
+```console
+{ echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
+printf "#cloud-config\nhostname: testhost\n" > user-data
+genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
 ```
 
 Attach the `seed.iso` generated above to your machine and reboot for the init to take effect.
@@ -51,18 +51,18 @@ In this case, the hostname is set to ```testhost```.
 Using a Seed Disk File
 ----------------
 To init using local disk files, do the following:
-```
+```console
 mkdir /var/lib/cloud/seed/nocloud
 cd /var/lib/cloud/seed/nocloud
-$ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-$ printf "#cloud-config\nhostname: testhost\n" > user-data
+{ echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
+printf "#cloud-config\nhostname: testhost\n" > user-data
 ```
 Reboot the machine and the hostname will be set to `testhost`.
 
 Frequencies
 -----------
 Cloud-init modules have predetermined frequencies. Based on the frequency setting, multiple runs will yield different results. For the scripts to always run, remove the `instances` directory before rebooting.
-```
+```console
 rm -rf /var/lib/cloud/instances
 ```
 

--- a/content/en/docs-v5/installation-guide/building-images/build-other-images/build-cloud-images.md
+++ b/content/en/docs-v5/installation-guide/building-images/build-other-images/build-cloud-images.md
@@ -1,0 +1,70 @@
+---
+title:  Building Cloud Images
+weight: 1
+---
+
+Perform the following steps to build the cloud images on Ubuntu: 
+
+1. Install the packages: 
+
+    ```bash
+    sudo apt-get -y install bison gawk g++ createrepo python-aptdaemon genisoimage texinfo python-requests libfuse-dev libssl-dev uuid-dev libreadline-dev kpartx git bc
+    ```
+
+2. Get Docker:
+
+    ```bash
+    wget -qO- https://get.docker.com/ | sh
+    ```
+ 
+3.  Install pip 
+   
+    ```bash
+    sudo apt install python3-pip
+    pip3 install git+https://github.com/vmware/photon-os-installer.git
+    git clone https://github.com/vmware/photon.git
+    ```
+    
+   If you encounter an error for LOCALE when you run these commands, then export the following variables in the terminal:
+    
+   
+       ` export LC_ALL="en_US.UTF-8"`
+   ` export LC_CTYPE="en_US.UTF-8"`
+
+3.  Clone the Photon project:
+   
+    ` git clone https://github.com/vmware/photon.git `
+    ` cd $HOME/workspaces/photon `
+
+4. Make the cloud image for AMI. 
+
+    
+    ` sudo make image IMG_NAME=ami `
+
+4. Make the cloud image for Azure. 
+  
+   
+    ` sudo make image IMG_NAME=azure `
+
+4. Make the cloud image for GCE. 
+    
+   
+    ` sudo make image IMG_NAME=gce `
+    
+    
+**Result**
+
+This command first builds all RPMs corresponding to the SPEC files in your Photon repository and then builds a bootable ISO containing those RPMs.
+
+
+The RPMs thus built are stored under ` stage/RPMS/` directory within the repository, using the following directory hierarchy:
+
+```tree
+$HOME/workspaces/photon/stage/:
+├──RPMS/:
+    ├──noarch/*.noarch.rpm    [Architecture-independent RPMs]
+    ├──x86_64/*.x86_64.rpm    [RPMs built for the x86-64 architecture]
+    ├──aarch64/*.aarch64.rpm  [RPMs built for the aarch64 (ARM64) architecture]
+```
+
+The cloud image is created at `$HOME/workspaces/photon`.


### PR DESCRIPTION
# Documentation Analysis Report

**Generated:** 2025-12-01T00-42-24.427646
**Tool:** photonos-docs-lecturer.py v1.3
**Last Updated:** 2025-12-01T00:43:27.153316
**Pages analyzed:** 15
**Issues found:** 71
**Fixes applied:** 4
**LLM Provider:** None (deterministic fixes only)

## Files Fixed

- `content/en/docs-v5/installation-guide/building-images/build-other-images/build-cloud-images.md`: backtick spacing
- `content/en/docs-v3/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md`: shell prompts
- `content/en/docs-v4/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md`: shell prompts
- `content/en/docs-v5/administration-guide/cloud-init-on-photon-os/cloud-init-overview.md`: shell prompts

## Issue Categories Detected and Fixed

### Deterministic Fixes (Applied Automatically)
- **VMware spelling**: Corrected incorrect spellings (vmware, Vmware, etc.) to VMware
- **Deprecated URLs**: Updated packages.vmware.com URLs to packages-prod.broadcom.com
- **Backtick spacing**: Fixed missing spaces before/after inline code
- **Shell prompts**: Removed shell prompt prefixes ($, #, ❯) from code blocks

### LLM-Assisted Fixes (Requires --llm flag)
- **Grammar/spelling errors**: Language and grammar corrections
- **Markdown artifacts**: Fixed unrendered markdown syntax
- **Mixed command/output**: Separated command and output into distinct code blocks

### Issues Reported (Manual Review Recommended)
- **Broken links**: Orphan URLs requiring manual verification
- **Broken images**: Missing or inaccessible image files
- **Unaligned images**: Images lacking proper CSS alignment
- **Indentation issues**: List item indentation problems

---
*This PR is updated incrementally as fixes are applied. Check the commit history for details.*
