### PR TITLE
Fix python3-setuptools: remove introduced wheel subpackage

### DIFF
--- a/SPECS/91/python3-setuptools/python3-setuptools.spec
+++ b/SPECS/91/python3-setuptools/python3-setuptools.spec
@@ -1,15 +1,13 @@
 %global build_if %{photon_subrelease} <= 91
 
 %define srcname             setuptools
-%define python_wheel_dir    %{_datadir}/python-wheels
-%define python_wheel_name   %{srcname}-%{version}-py3-none-any.whl
 
 Summary:        Extensions to the standard Python datetime module
 Name:           python3-setuptools
 # if you make any security fix in this package, package the whl files
 # python3.spec without miss
 Version:        69.0.3
-Release:        8.1%{?dist}
+Release:        8.2%{?dist}
 Group:          Development/Languages/Python
 Vendor:         VMware, Inc.
 Distribution:   Photon
@@ -26,8 +24,6 @@ Patch1: CVE-2025-47273.patch
 BuildRequires: python3-devel
 BuildRequires: python3-xml
 
-%define ExtraBuildRequires python3-wheel
-
 Requires:       python3
 Requires:       python3-xml
 Requires(post): findutils
@@ -42,23 +38,15 @@ designed to facilitate packaging Python projects.
 It helps developers to easily share reusable code (in the form of a library) and programs
 (e.g., CLI/GUI tools implemented in Python), that can be installed with pip and uploaded to PyPI.
 
-%package wheel
-Summary:        The setuptools wheel
-
-%description wheel
-A Python wheel of setuptools to use with venv.
-
 %prep
 %autosetup -p1 -n %{srcname}-%{version}
 
 %build
-%{python3} setup.py bdist_wheel
+%py3_build
 
 %install
-%{py3_install}
+%py3_install
 find %{buildroot}%{python3_sitelib} -name '*.exe' -delete
-mkdir -p %{buildroot}%{python_wheel_dir}
-install -p dist/%{python_wheel_name} -t %{buildroot}%{python_wheel_dir}
 
 %check
 %{py3_test}
@@ -73,12 +61,9 @@ rm -rf %{buildroot}
 %defattr(-,root,root,755)
 %{python3_sitelib}/*
 
-%files wheel
-%defattr(-,root,root,755)
-%dir %{python_wheel_dir}
-%{python_wheel_dir}/%{python_wheel_name}
-
 %changelog
+* Sat Mar 28 2026 Factory AI Bot <factory-droid[bot]@users.noreply.github.com> 69.0.3-8.2
+- Remove erroneously introduced wheel subpackage and ExtraBuildRequires
 * Wed Mar 18 2026 Prashant S Chauhan <prashant.singh-chauhan@broadcom.com> 69.0.3-8.1
 - Bump after moving to SPECS/91
 * Wed May 28 2025 Prashant S Chauhan <prashant.singh-chauhan@broadcom.com> 69.0.3-8

--- a/SPECS/91/python3-setuptools/python3-setuptools.spec
+++ b/SPECS/91/python3-setuptools/python3-setuptools.spec
@@ -26,7 +26,7 @@ Patch1: CVE-2025-47273.patch
 BuildRequires: python3-devel
 BuildRequires: python3-xml
 
-%define ExtraBuildRequires: python3-wheel
+%define ExtraBuildRequires python3-wheel
 
 Requires:       python3
 Requires:       python3-xml


### PR DESCRIPTION
The root cause is a circular dependency: python3-setuptools needs python3-wheel (via ExtraBuildRequires) to run bdist_wheel, but python3-wheel requires python3-setuptools to build. Since ExtraBuildRequires is not used by the scheduler for build ordering, and the installExtraToolchainRPMS only looks at the local packages repo (which doesn't have python3-wheel yet), the wheel package is not available at build time.

Nothing depends on the python3-setuptools-wheel subpackage, so the fix is to change the build to use %py3_build (standard setup.py build) instead of bdist_wheel, and remove the wheel subpackage.

The fix is applied to SPECS/91/python3-setuptools/python3-setuptools.spec. Here's what was changed:

1. Removed `%define ExtraBuildRequires python3-wheel` -- this dependency can't be satisfied during a clean build because python3-wheel itself requires python3-setuptools (circular dependency), and the ExtraBuildRequires mechanism only installs from the local packages repo where wheel hasn't been built yet.

2. Changed `%build` from `%{python3} setup.py bdist_wheel` to `%py3_build` -- uses the standard setup.py build which doesn't require the wheel package.

3. Removed the `wheel` subpackage (%package wheel, %description wheel, %files wheel) and associated install steps -- since we no longer produce a .whl file, and nothing in the build depends on python3-setuptools-wheel.

4. Removed unused `%define` macros for python_wheel_dir and python_wheel_name.