### PR TITLE
photon-os-installer: fix pkg_resources deprecation

### DIFF
--- a/SPECS/photon-os-installer/fix-pkg-resources.patch
+++ b/SPECS/photon-os-installer/fix-pkg-resources.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Factory AI Bot <factory-droid[bot]@users.noreply.github.com>
+Date: Mon, 30 Mar 2026 20:00:00 +0200
+Subject: [PATCH] Replace deprecated pkg_resources with importlib.metadata
+
+Python 3.14 deprecates pkg_resources. Use importlib.metadata.version()
+instead, matching the fix already present in upstream master.
+
+---
+ photon_installer/__init__.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/photon_installer/__init__.py b/photon_installer/__init__.py
+--- a/photon_installer/__init__.py
++++ b/photon_installer/__init__.py
+@@ -5,7 +5,7 @@
+ 
+ import sys
+ import glob
+-import pkg_resources
++from importlib.metadata import version as _get_version
+ from os.path import dirname, basename, isfile, join
+ 
+ 
+@@ -13,4 +13,4 @@ modules = glob.glob(join(dirname(__file__), "*.py"))
+ __all__ = [ basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+ sys.path.append(dirname(__file__))
+ 
+-__version__ = pkg_resources.get_distribution(__name__).version
++__version__ = _get_version(__name__)

--- a/SPECS/photon-os-installer/photon-os-installer.spec
+++ b/SPECS/photon-os-installer/photon-os-installer.spec
@@ -5,7 +5,7 @@
 Summary:       Photon OS Installer
 Name:          photon-os-installer
 Version:       2.7
-Release:       5%{?dist}
+Release:       6%{?dist}
 Group:         System Environment/Base
 Vendor:        VMware, Inc.
 Distribution:  Photon
@@ -16,6 +16,7 @@ Source1: license.txt
 %include %{SOURCE1}
 
 Patch0: 0001-Use-mkpasswd-to-generate-password-hash.patch
+Patch1: fix-pkg-resources.patch
 
 BuildRequires: python3-devel
 BuildRequires: python3-pyinstaller
@@ -70,6 +71,8 @@ rm -rf %{buildroot}
 %{_bindir}/photon-iso-builder
 
 %changelog
+* Mon Apr 13 2026 Factory AI Bot <factory-droid[bot]@users.noreply.github.com> 2.7-6
+- Replace deprecated pkg_resources with importlib.metadata
 * Tue Mar 24 2026 Shreenidhi Shedi <shreenidhi.shedi@broadcom.com> 2.7-5
 - Use mkpasswd to generate password
 * Wed Mar 18 2026 Prashant S Chauhan <prashant.singh-chauhan@broadcom.com> 2.7-4


### PR DESCRIPTION
## Problem

The photon-os-installer v2.7 source tarball uses `pkg_resources` (from setuptools) to resolve its own version in `photon_installer/__init__.py`. `pkg_resources` is deprecated in setuptools 67.5+ and will be removed in a future release. On Photon OS 5.0 (subrelease >= 92) with Python 3.14 and setuptools 80.x, `pkg_resources` is still shipped but triggers deprecation warnings and is on the removal path.

## Fix

**Patch: `fix-pkg-resources.patch`** (Patch1, Release 2.7-6):

- Replace `import pkg_resources` / `pkg_resources.get_distribution(__name__).version` with `from importlib.metadata import version` / `version(__name__)`, matching the approach already used in upstream master.

The patch applies to the existing source tarball via `%autosetup -p1`. No source tarball SHA change is needed.

> **Note:** The upstream source tarball already contains the `btrfs-progs` auto-install logic (`self._add_packages_to_install('btrfs-progs')` in `installer.py`), so no separate btrfs-progs fix is required.

## Testing

| Python version | Without PR | With PR |
|---------------|-----------|---------|
| 3.11 (pinned91) | Works (deprecation warning) | Works (no warning) |
| 3.14 (>= 92) | Works (deprecation warning, future removal risk) | Works (no warning) |

Tested on Photon 5.0 (pinned subrelease 91 and normal) and Photon 6.0, on VMware Workstation (UEFI, TPM 2.0, VM encryption).