### PR TITLE
Fix STIG playbook: PAM faillock guard, FIPS module config, IMA hash

### DIFF
--- a/SPECS/91/stig-hardening/fix-stig-playbook-fips-pam.patch
+++ b/SPECS/91/stig-hardening/fix-stig-playbook-fips-pam.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Factory AI Bot <factory-droid[bot]@users.noreply.github.com>
+Date: Thu, 02 Apr 2026 15:00:00 +0200
+Subject: [PATCH] Fix STIG playbook: PAM stack, FIPS module config, IMA hash
+
+1) Fix PHTN-50-000192 pam_faillock.so setup: regex_search() in
+   set_fact returns None when no match. The comparison
+   'preauthsearch == ""' evaluates to False when preauthsearch is
+   None, causing the cleanup step to be skipped while add steps
+   still run, corrupting the PAM auth stack with duplicate entries.
+   Use '| default("")' so None is treated as empty string.
+   (Backward-compatible: no-op when value is already a string on
+   older Ansible.)
+
+2) Add ima_hash=sha256 kernel parameter when fips=1 is active.
+   FIPS mode disables sha1 but IMA defaults to sha1, causing
+   allocation failures during boot.
+
+3) Generate /etc/ssl/fipsmodule.cnf via 'openssl fipsinstall' when
+   the FIPS provider module is present but fipsmodule.cnf is missing.
+   Without it, booting with fips=1 causes OpenSSL to fail to
+   initialize FIPS mode and pam_unix.so cannot verify passwords.
+
+Signed-off-by: Factory AI Bot <factory-droid[bot]@users.noreply.github.com>
+---
+diff -ruN a/tasks/photon.yml b/tasks/photon.yml
+--- a/tasks/photon.yml	2026-04-02 14:09:20.577266299 +0200
++++ b/tasks/photon.yml	2026-04-02 14:10:05.298254183 +0200
+@@ -305,6 +305,17 @@
+         - run_openssl_fips_install | bool
+         - opensslfipsinstalled.stdout == ""
+ 
++    - name: PHTN-50-000013 - Check if FIPS module is present
++      ansible.builtin.stat:
++        path: /usr/lib/ossl-modules/fips.so
++      register: fips_module_file
++
++    - name: PHTN-50-000013 - Generate FIPS module config if missing
++      ansible.builtin.command: openssl fipsinstall -out /etc/ssl/fipsmodule.cnf -module /usr/lib/ossl-modules/fips.so
++      args:
++        creates: /etc/ssl/fipsmodule.cnf
++      when: fips_module_file.stat.exists
++
+ ###################################################################################################################################
+ - name: PHTN-50-000014 - Configure auditd.conf write_logs
+   tags: [PHTN-50-000014, auditd]
+@@ -1183,6 +1194,12 @@
+         regexp: '^(\s*linux(?!.* fips=).*)'
+         replace: '\1 fips=1'
+ 
++    - name: PHTN-50-000182 - Add ima_hash=sha256 when fips=1 is active
++      ansible.builtin.replace:
++        path: '{{ var_grub_conf_file }}'
++        regexp: '^(\s*linux(?!.* ima_hash=).*fips=1.*)'
++        replace: '\1 ima_hash=sha256'
++
+     - name: PHTN-50-000080 - Replace fips=1 in /boot/grub2/grub.cfg
+       ansible.builtin.replace:
+         path: '{{ var_grub_conf_file }}'
+@@ -1320,7 +1337,7 @@
+         state: absent
+         regexp: '^auth\s+(required|requisite|\[default=die\])\s+pam_faillock\.so.*$'
+       when:
+-        - preauthsearch == "" or authfailsearch == ""
++        - preauthsearch | default('') == "" or authfailsearch | default('') == ""
+ 
+     - name: Ensure pam_unix.so auth control is 'sufficient' in system-auth if it is 'required'
+       ansible.builtin.replace:
+@@ -1375,7 +1392,7 @@
+         module_path: pam_faillock.so
+         state: absent
+       when:
+-        - sysaccountsearch == ""
++        - sysaccountsearch | default('') == ""
+ 
+     - name: PHTN-50-000192 - Add pam_faillock.so to system-account if it doesn't exist
+       community.general.pamd:
+-- 
+2.43.7

--- a/SPECS/91/stig-hardening/stig-hardening.spec
+++ b/SPECS/91/stig-hardening/stig-hardening.spec
@@ -4,7 +4,7 @@ Summary:        VMware Photon OS 5.0 STIG Readiness Guide Ansible Playbook
 Name:           stig-hardening
 #Version x.y.z corresponds v<x>r<y>-z tag in the repo. Eg 1.1.1 = v1r1-1
 Version:        2.1
-Release:        5.1%{?dist}
+Release:        5.2%{?dist}
 URL:            https://github.com/vmware/dod-compliance-and-automation/tree/master/photon/5.0/ansible/vmware-photon-5.0-stig-ansible-hardening
 Group:          Productivity/Security
 Vendor:         VMware, Inc.
@@ -22,6 +22,7 @@ Source1: license.txt
 
 Patch0: fix-some-value-checks.patch
 Patch1: system-auth-fix.patch
+Patch2: fix-stig-playbook-fips-pam.patch
 
 Requires: ansible >= 2.14.2
 Requires: ansible-community-general
@@ -43,6 +44,9 @@ cp -a %{_builddir}/%{name}-ph5-%{version}/ %{buildroot}%{_datadir}/ansible/%{nam
 %{_datadir}/ansible/
 
 %changelog
+* Mon May 11 2026 Daniel Casota <dcasota@gmail.com> 2.1-5.2
+- Add fix-stig-playbook-fips-pam.patch (FIPS module config + IMA hash;
+  PAM faillock | default('') guard is a defensive no-op on Ansible 2.14+)
 * Wed Apr 01 2026 Shreenidhi Shedi <shreenidhi.shedi@broadcom.com> 2.1-5.1
 - Bump after moving to SPECS/91
 * Wed Mar 25 2026 Shreenidhi Shedi <shreenidhi.shedi@broadcom.com> 2.1-5

--- a/SPECS/stig-hardening/fix-stig-playbook-fips-pam.patch
+++ b/SPECS/stig-hardening/fix-stig-playbook-fips-pam.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Factory AI Bot <factory-droid[bot]@users.noreply.github.com>
+Date: Thu, 02 Apr 2026 15:00:00 +0200
+Subject: [PATCH] Fix STIG playbook: PAM stack, FIPS module config, IMA hash
+
+1) Fix PHTN-50-000192 pam_faillock.so setup: regex_search() in
+   set_fact returns None when no match. The comparison
+   'preauthsearch == ""' evaluates to False when preauthsearch is
+   None, causing the cleanup step to be skipped while add steps
+   still run, corrupting the PAM auth stack with duplicate entries.
+   Use '| default("")' so None is treated as empty string.
+   (Backward-compatible: no-op when value is already a string on
+   older Ansible.)
+
+2) Add ima_hash=sha256 kernel parameter when fips=1 is active.
+   FIPS mode disables sha1 but IMA defaults to sha1, causing
+   allocation failures during boot.
+
+3) Generate /etc/ssl/fipsmodule.cnf via 'openssl fipsinstall' when
+   the FIPS provider module is present but fipsmodule.cnf is missing.
+   Without it, booting with fips=1 causes OpenSSL to fail to
+   initialize FIPS mode and pam_unix.so cannot verify passwords.
+
+Signed-off-by: Factory AI Bot <factory-droid[bot]@users.noreply.github.com>
+---
+diff -ruN a/tasks/photon.yml b/tasks/photon.yml
+--- a/tasks/photon.yml	2026-04-02 14:09:20.577266299 +0200
++++ b/tasks/photon.yml	2026-04-02 14:10:05.298254183 +0200
+@@ -305,6 +305,17 @@
+         - run_openssl_fips_install | bool
+         - opensslfipsinstalled.stdout == ""
+ 
++    - name: PHTN-50-000013 - Check if FIPS module is present
++      ansible.builtin.stat:
++        path: /usr/lib/ossl-modules/fips.so
++      register: fips_module_file
++
++    - name: PHTN-50-000013 - Generate FIPS module config if missing
++      ansible.builtin.command: openssl fipsinstall -out /etc/ssl/fipsmodule.cnf -module /usr/lib/ossl-modules/fips.so
++      args:
++        creates: /etc/ssl/fipsmodule.cnf
++      when: fips_module_file.stat.exists
++
+ ###################################################################################################################################
+ - name: PHTN-50-000014 - Configure auditd.conf write_logs
+   tags: [PHTN-50-000014, auditd]
+@@ -1183,6 +1194,12 @@
+         regexp: '^(\s*linux(?!.* fips=).*)'
+         replace: '\1 fips=1'
+ 
++    - name: PHTN-50-000182 - Add ima_hash=sha256 when fips=1 is active
++      ansible.builtin.replace:
++        path: '{{ var_grub_conf_file }}'
++        regexp: '^(\s*linux(?!.* ima_hash=).*fips=1.*)'
++        replace: '\1 ima_hash=sha256'
++
+     - name: PHTN-50-000080 - Replace fips=1 in /boot/grub2/grub.cfg
+       ansible.builtin.replace:
+         path: '{{ var_grub_conf_file }}'
+@@ -1320,7 +1337,7 @@
+         state: absent
+         regexp: '^auth\s+(required|requisite|\[default=die\])\s+pam_faillock\.so.*$'
+       when:
+-        - preauthsearch == "" or authfailsearch == ""
++        - preauthsearch | default('') == "" or authfailsearch | default('') == ""
+ 
+     - name: Ensure pam_unix.so auth control is 'sufficient' in system-auth if it is 'required'
+       ansible.builtin.replace:
+@@ -1375,7 +1392,7 @@
+         module_path: pam_faillock.so
+         state: absent
+       when:
+-        - sysaccountsearch == ""
++        - sysaccountsearch | default('') == ""
+ 
+     - name: PHTN-50-000192 - Add pam_faillock.so to system-account if it doesn't exist
+       community.general.pamd:
+-- 
+2.43.7

--- a/SPECS/stig-hardening/stig-hardening.spec
+++ b/SPECS/stig-hardening/stig-hardening.spec
@@ -4,7 +4,7 @@ Summary:        VMware Photon OS 5.0 STIG Readiness Guide Ansible Playbook
 Name:           stig-hardening
 #Version x.y.z corresponds v<x>r<y>-z tag in the repo. Eg 1.1.1 = v1r1-1
 Version:        2.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 URL:            https://github.com/vmware/dod-compliance-and-automation/tree/master/photon/5.0/ansible/vmware-photon-5.0-stig-ansible-hardening
 Group:          Productivity/Security
 Vendor:         VMware, Inc.
@@ -23,6 +23,7 @@ Source1: license.txt
 Patch0: fix-some-value-checks.patch
 Patch1: system-auth-fix.patch
 Patch2: fix-photon.yml-for-latest-audit-and-ansible.patch
+Patch3: fix-stig-playbook-fips-pam.patch
 
 Requires: ansible >= 2.20.1
 Requires: ansible-community-general
@@ -44,6 +45,10 @@ cp -a %{_builddir}/%{name}-ph5-%{version}/ %{buildroot}%{_datadir}/ansible/%{nam
 %{_datadir}/ansible/
 
 %changelog
+* Thu Apr 09 2026 Factory AI Bot <factory-droid[bot]@users.noreply.github.com> 2.1-7
+- Fix PHTN-50-000192 pam_faillock PAM stack corruption (| default guard)
+- Add ima_hash=sha256 kernel parameter when fips=1 is active
+- Generate fipsmodule.cnf when FIPS provider is present but config is missing
 * Wed Apr 01 2026 Shreenidhi Shedi <shreenidhi.shedi@broadcom.com> 2.1-6
 - Fix conditions for ansible-2.20 and audit-4.x
 * Wed Mar 25 2026 Shreenidhi Shedi <shreenidhi.shedi@broadcom.com> 2.1-5


### PR DESCRIPTION
## Problem

Upstream commit [`85c56e7`](https://github.com/vmware/photon/commit/85c56e71275f931ff8fa5d6edaedc01fa7042653) (Patch2, Release 2.1-6) fixed the STIG hardening playbook for Ansible 2.20 boolean conditionals and audit 4.x tool renames, but left three gaps:

1. **PHTN-50-000192 PAM stack corruption**: The `regex_search()` in the PAM faillock cleanup `set_fact` still returns `None` under Ansible 2.20. The comparison `preauthsearch == ""` evaluates to `False` when `preauthsearch` is `None`, causing the cleanup step to be skipped while the add step still runs, producing duplicate `pam_faillock.so` entries in `/etc/pam.d/system-auth`.

2. **Missing `ima_hash=sha256`**: IMA defaults to SHA1 which is disabled under FIPS, causing `ima: Can not allocate sha1 (reason: -2)` during boot.

3. **Missing `fipsmodule.cnf`**: When the FIPS provider is installed but `/etc/ssl/fipsmodule.cnf` is absent, OpenSSL cannot initialize FIPS mode and `pam_unix.so` fails to verify passwords.

## Fix

**Patch: `fix-stig-playbook-fips-pam.patch`** (Patch3, Release 2.1-7) -- all changes are backward-compatible with Ansible 2.14+:

1. Add `| default('')`to PHTN-50-000192 `when:` conditions (no-op when value is already a string on older Ansible)
2. Add `ima_hash=sha256` kernel parameter when `fips=1` is active
3. Generate `/etc/ssl/fipsmodule.cnf` via `openssl fipsinstall` when the FIPS provider is present but config is missing

## Compatibility

| Fix | Photon 5.0 (Ansible 2.20) | Photon 5.0 pinned91 / 6.0 (Ansible 2.14+) |
|-----|---------------------------------------|---------------------------------------|
| `\| default('')`| Prevents `None` comparison error | No-op (value already a string) |
| `ima_hash=sha256` | Fixes IMA allocation failure under FIPS | Same fix needed if FIPS enabled |
| `fipsmodule.cnf` generation | Fixes OpenSSL FIPS init | Same fix needed if FIPS enabled |

## Testing

Tested on VMware Workstation (UEFI, TPM 2.0, VM encryption):

| Build | IMA hash | fipsmodule.cnf | PAM faillock |
|-------|:---:|:---:|:---:|
| 5.0 pinned91 | sha256 allocated, no error | Generated | Correct (2 entries) |
| 5.0 normal (>= 92) | sha256 allocated (sha1 non-fatal kernel error persists) | Generated | Correct (2 entries) |
| 6.0 | sha256 allocated (sha1 non-fatal kernel error persists) | Generated | Correct (2 entries) |

## Known Issue: IMA SHA1 allocation under FIPS

The `ima_hash=sha256` parameter redirects IMA file measurements to SHA256, but the kernel still attempts SHA1 for the PCR bank (`ima: Can not allocate sha1 (reason: -2)`). This is non-fatal. A full fix requires `CONFIG_IMA_DEFAULT_HASH_SHA256` in the kernel, as tracked in [Ubuntu Bug #2041735](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2041735).