### PR TITLE
docker, tini: link docker-init statically to fix docker run --init

### DIFF
--- a/SPECS/docker/docker.spec
+++ b/SPECS/docker/docker.spec
@@ -12,7 +12,7 @@
 Summary:        Docker
 Name:           docker
 Version:        28.2.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 URL:            http://docs.docker.com
 Group:          Applications/File
 Vendor:         VMware, Inc.
@@ -56,6 +56,11 @@ Docker is an open source project to build, ship and run any application as a lig
 
 %package        engine
 Summary:        Docker Engine
+# docker-init is bind-mounted into containers and exec'd as PID 1 there, so it
+# must not depend on the container's libc. The dependency is versioned because
+# tini-static first appears in tini-0.19.0-2; an unversioned one would let an
+# older tini satisfy it and leave /usr/bin/docker-init dangling.
+Requires:       tini-static >= 0.19.0-2
 Requires:       libapparmor
 Requires:       libseccomp
 Requires:       libltdl
@@ -188,7 +193,7 @@ install -p -m 755 src/%{gopath_comp_engine}/bundles/dynbinary-daemon/dockerd %{b
 install -p -m 755 src/%{gopath_comp_engine}/bundles/dynbinary-daemon/docker-proxy %{buildroot}%{_bindir}/docker-proxy
 
 # install tini
-ln -srv %{buildroot}%{_bindir}/tini %{buildroot}%{_bindir}/docker-init
+ln -srv %{buildroot}%{_bindir}/tini-static %{buildroot}%{_bindir}/docker-init
 
 # install udev rules
 install -p -m 644 src/%{gopath_comp_engine}/contrib/udev/80-docker.rules %{buildroot}%{_udevrulesdir}/80-docker.rules
@@ -298,6 +303,8 @@ rm -rf %{buildroot}/*
 %{_bindir}/dockerd-rootless-setuptool.sh
 
 %changelog
+* Fri Aug 07 2026 Daniel Casota <dcasota@gmail.com> 28.2.2-4
+- Point docker-init at tini-static so --init works in non-glibc containers
 * Mon Nov 17 2025 Mukul Sikka <mukul.sikka@broadcom.com> 28.2.2-3
 - Bump up version as a part of containerd upgrade
 * Mon Nov 10 2025 Mukul Sikka <mukul.sikka@broadcom.com> 28.2.2-2

--- a/SPECS/tini/tini-disable-git.patch
+++ b/SPECS/tini/tini-disable-git.patch
@@ -1,0 +1,34 @@
+From a778da75578051d31a4badcf781f6d3af2b6b65b Mon Sep 17 00:00:00 2001
+From: Bo Gan <ganb@vmware.com>
+Date: Mon, 28 Oct 2019 17:14:22 -0700
+Subject: [PATCH] disable git invocation
+
+---
+ CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 490bec8..0c897a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,8 @@ if(MINIMAL)
+ 	add_definitions(-DTINI_MINIMAL=1)
+ endif()
+ 
++if(FALSE)
++
+ # Extract git version and dirty-ness
+ execute_process (
+   COMMAND git --git-dir "${PROJECT_SOURCE_DIR}/.git" --work-tree "${PROJECT_SOURCE_DIR}" log -n 1 --date=local --pretty=format:%h
+@@ -27,6 +29,8 @@ execute_process(
+   OUTPUT_VARIABLE git_dirty_check_out
+ )
+ 
++endif()
++
+ if("${git_version_check_ret}" EQUAL 0)
+   set(tini_VERSION_GIT " - git.${tini_VERSION_GIT}")
+   if(NOT "${git_dirty_check_out}" STREQUAL "")
+-- 
+2.7.4
+

--- a/SPECS/tini/tini.spec
+++ b/SPECS/tini/tini.spec
@@ -3,7 +3,7 @@
 
 Name:           tini
 Version:        0.19.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A tiny but valid init for containers
 Vendor:         VMware, Inc.
 Group:          System Environment/Base
@@ -14,6 +14,13 @@ Source0:        https://github.com/krallin/tini/archive/%{name}-%{version}.tar.g
 Source1: license.txt
 %include %{SOURCE1}
 
+# tini's CMakeLists.txt overwrites tini_VERSION_GIT and git_version_check_ret
+# from execute_process(), which clobbers the -D values passed below. An RPM
+# builds from a tarball with no .git, so the git call fails and the version
+# suffix is silently dropped, leaving `docker info` with an empty init version.
+# This patch disables the git invocation so the -D values take effect.
+Patch0:         tini-disable-git.patch
+
 BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  glibc-devel
@@ -23,6 +30,16 @@ Tini is a trivial implementation for an "init" program.
 All Tini does is spawn a single child (Tini is meant to be run in a container),
 and wait for it to exit, all the while reaping zombies and performing signal forwarding.
 libc will be needed inside the container.
+
+%package        static
+Summary:        Standalone static build of tini
+
+%description    static
+Statically linked build of tini, meant to be used inside a container.
+Because this binary carries no dynamic dependencies it can be bind-mounted
+into a container built against any libc (glibc, musl) or into one with no
+libc at all, which is what the container runtime requires of an init that
+it injects from the host.
 
 %prep
 %autosetup -p1 -c
@@ -43,8 +60,14 @@ export CFLAGS
 %files
 %defattr(-,root,root,-)
 %{_bindir}/tini
-%exclude %{_bindir}/tini-static
+
+%files static
+%defattr(-,root,root,-)
+%{_bindir}/tini-static
 
 %changelog
+* Fri Aug 07 2026 Daniel Casota <dcasota@gmail.com> 0.19.0-2
+- Ship tini-static in a new subpackage instead of discarding it
+- Restore tini-disable-git.patch so the version suffix is not dropped
 * Tue Apr 08 2025 Harinadh Dommaraju <Harinadh.Dommaraju@broadcom.com> 0.19.0-1
 - Initial build


### PR DESCRIPTION
Part of #1605. This is the 6.0 counterpart of https://github.com/vmware/photon/pull/1661 (5.0); the defect and the change are identical.

`docker run --init` (and compose `init: true`) fails on any container whose rootfs has no glibc loader:

```
exec /sbin/docker-init: no such file or directory
```

## `/sbin/docker-init` is not a host path

It is the hardcoded **in-container** destination. From moby `daemon/oci_linux.go`:

```go
const inContainerInitPath = "/sbin/" + dconfig.DefaultInitBinary  // "/sbin/docker-init"

s.Process.Args = append([]string{inContainerInitPath, "--", c.Path}, c.Args...)
path, err := daemonCfg.LookupInitPath() // resolves the HOST binary
s.Mounts = append(s.Mounts, specs.Mount{
    Destination: inContainerInitPath,   // /sbin/docker-init INSIDE the container
    Type: "bind", Source: path, Options: []string{"bind", "ro"},
})
```

`LookupInitPath()` searches the libexec dirs and then `$PATH`, finds `/usr/bin/docker-init`, and bind-mounts it (the symlink is resolved by the mount) into the container, which then execs it as PID 1.

## Why it fails

`/usr/bin/docker-init` is a dynamic PIE, so the kernel must load `/lib64/ld-linux-x86-64.so.2` from the **container's** rootfs. Alpine only ships `/lib/ld-musl-x86_64.so.1`. `execve` reports a missing ELF interpreter as `ENOENT`, which surfaces as "no such file or directory" for a file that is plainly present.

The failure was reproduced on Photon 5.0 (`docker-29.5.3-1.ph5` / `tini-0.19.0-2.ph5`). 6.0 carries the identical packaging — `ln -srv %{buildroot}%{_bindir}/tini %{buildroot}%{_bindir}/docker-init` plus a `tini.spec` that excludes `tini-static` — so it has the same defect:

```
# docker run --rm --init nginx:1-alpine true
exec /sbin/docker-init: no such file or directory

# docker run --rm --init debian:12 true            <- glibc image
(succeeds)

# docker run --rm -v /usr/bin/tini:/t:ro alpine:3 sh -c '/t --version'
sh: /t: not found                                   <- same ENOENT, no --init involved

# docker run --rm alpine:3 ls /lib64/ld-linux-x86-64.so.2
ls: /lib64/ld-linux-x86-64.so.2: No such file or directory
```

`debian:12` succeeding is the control: a wrong host path would break every image, not only those without a glibc loader.

## Where it regressed

Commit b3da2fa72 ("tini: Initial commit / Also seperate out tini from docker spec"), which landed on both 5.0 and 6.0. Before it, `docker.spec` built tini itself and installed a statically linked binary:

```spec
make tini-static %{?_smp_mflags}
cp tini-static "$GOPATH/bin/docker-init"
install -p -m 755 bin/docker-init %{buildroot}%{_bindir}/docker-init
```

after it, `docker-init` became a symlink to the dynamically linked `/usr/bin/tini`, and the new `SPECS/tini/tini.spec` builds `tini-static` only to discard it with `%exclude %{_bindir}/tini-static`.

`master`/`dev`/`4.0` are unaffected — they still build `docker-init` statically.

Upstream moby links `docker-init` statically on purpose: `hack/dockerfile/install/tini.installer` runs `make tini-static`, and the Dockerfile asserts it with `xx-verify --static`. Fedora does the same, shipping a `tini-static` subpackage that `moby-engine` depends on.

## Changes

**`SPECS/tini/tini.spec`** (0.19.0-1 → 0.19.0-2)

- Package `tini-static` in a new subpackage instead of excluding it. The binary is already built and installed into the buildroot by `%cmake_build` / `%cmake_install`; the `%exclude` existed only to stop RPM's unpackaged-files check from failing the build.
- Restore `tini-disable-git.patch`, also dropped by b3da2fa72. tini's `CMakeLists.txt` overwrites `tini_VERSION_GIT` and `git_version_check_ret` via `execute_process()`, clobbering the `-D` values the spec passes. An RPM builds from a tarball with no `.git`, so the git call fails and the version suffix is silently dropped. moby parses `docker-init --version` expecting `tini version X.Y.Z - git.COMMIT`, so `docker info` currently reports an empty `init version:`.

**`SPECS/docker/docker.spec`** (28.2.2-3 → 28.2.2-4)

- Point `docker-init` at `tini-static`.
- Add `Requires: tini-static >= 0.19.0-2` to `docker-engine`, the subpackage that actually ships `/usr/bin/docker-init`.

The version bound is deliberate. I simulated an upgrade in which `docker-engine` lands while an older `tini` without `tini-static` is installed: the dangling symlink reproduces the **identical** error message, so an unversioned dependency would leave that window open.

`Requires: tini` stays on the `docker` metapackage. `docker` is currently the only package requiring `tini`, so removing it would orphan `/usr/bin/tini` to `tdnf autoremove` — out of scope for this fix.

## Verification

The packages were built and tested from the 5.0 branch, where the change is line-for-line the same apart from the release numbers:

```
rpm -qlp tini-0.19.0-3.rpm         -> /usr/bin/tini
rpm -qlp tini-static-0.19.0-3.rpm  -> /usr/bin/tini-static
file /usr/bin/tini-static          -> ELF 64-bit LSB executable, statically linked
readelf -l /usr/bin/tini-static    -> 0 INTERP segments
/usr/bin/tini-static --version     -> tini version 0.19.0 - git.de40ad0
```

With `docker-init` symlinked to `tini-static` exactly as the spec creates it:

```
# docker run --rm --init nginx:1-alpine true
(succeeds)
# docker run --rm --init nginx:1-alpine ps -o pid,comm
PID   COMMAND
    1 docker-init
```

Note on scope of testing: the RPM build was done locally, not through the Photon build system, and the 6.0 packages themselves were not built — a builder run on this branch is worth doing before merge.

