### PR TITLE
Update nginx to 1.30.4 to fix CVE-2026-42533

### DIFF
--- a/SPECS/nginx/config.yaml
+++ b/SPECS/nginx/config.yaml
@@ -19,15 +19,15 @@ sources:
       license_declared: BSD-3-Clause AND BSD-2-Clause
       short_summary: Set, add, and clear arbitrary output headers in NGINX http servers.
       supplier: 'Organization: Broadcom, Inc.'
-- archive: nginx-1.28.3.tar.gz
-  archive_sha512sum: 2064175fd1d5fe591f006af9751109bae8dc3a6cecd13791dbce3133b8a9d5436e58b41dd7bbd9f4d5abf78e6d2389a78106eb890e2a4226f10f6681570e0571
+- archive: nginx-1.30.4.tar.gz
+  archive_sha512sum: 48c21de65fa188137a4088d02c28e2533a7164040bf19281637e025012e6d03afcacb0ee15463a107685a2a221037f24ce15fc89c46b6f7a36b94443d3993bf1
   skip_validation: false
   archive_type: upstream
-  name: "nginx-1.28.3"
-  version: 1.28.3
-  url: https://github.com/nginx/nginx/releases/download/release-1.28.3/nginx-1.28.3.tar.gz
+  name: "nginx-1.30.4"
+  version: 1.30.4
+  url: https://github.com/nginx/nginx/releases/download/release-1.30.4/nginx-1.30.4.tar.gz
   repo_url: https://github.com/nginx/nginx
-  commit_id: 9b958b000776c88036cd800c66e7e4ad39e6fd41
+  commit_id: bcf342539875c809e59348561856130b52ae29ce
   skip_list: []
   missing: [html, docs, CHANGES, misc, man, configure, CHANGES.ru, .gitignore, .github]
   spdx:

--- a/SPECS/nginx/nginx.spec
+++ b/SPECS/nginx/nginx.spec
@@ -7,7 +7,7 @@
 Summary:        High-performance HTTP server and reverse proxy
 Name:           nginx
 Epoch:          1
-Version:        1.28.3
+Version:        1.30.4
 Release:        1%{?dist}
 URL:            http://nginx.org
 Group:          Applications/System
@@ -204,6 +204,8 @@ rm -rf %{buildroot}
 %{dyn_modules_dir}/ngx_stream_ssl_preread_module.so
 
 %changelog
+* Tue Aug 18 2026 Uwe <java.entwickler@outlook.de> 1.30.4-1
+- Update to version 1.30.4 to fix CVE-2026-42533 (heap buffer overflow in map directive with regex)
 * Tue Mar 31 2026 Ankit Jain <ankit-aj.jain@broadcom.com> 1.28.3-1
 - Upgrade to v1.28.3
 - Drop CVE-2025-53859 patch, fixed upstream in v1.28.1


### PR DESCRIPTION
## Summary
Bumps the nginx package from 1.28.3 to 1.30.4 to fix CVE-2026-42533,
a critical heap buffer overflow (CVSS 9.2) in nginx's map directive
regex handling. An unauthenticated remote attacker can trigger this
via crafted HTTP requests, causing a worker crash (DoS) and
potentially RCE under certain conditions (ASLR disabled/bypassable).

## Details
- Vulnerable range: nginx 0.9.6 through 1.31.2
- Fixed upstream in nginx 1.30.4 (stable) / 1.31.3 (mainline), 2026-07-15
- This affects Photon's `nginx` package (SPECS/nginx/) and downstream
  consumers such as `goharbor/nginx-photon`, which as of Harbor v2.15.0
  still ships the vulnerable 1.26.3/1.28.3 builds.

## Changes
- `SPECS/nginx/nginx.spec`: version bump 1.28.3 → 1.30.4
- `SPECS/nginx/config.yaml`: updated archive metadata (sha512sum,
  commit_id, download URL) for the 1.30.4 source tarball

## References
- https://nginx.org/en/CHANGES (entry for 1.31.3, 15 Jul 2026)
- https://github.com/vmware/photon/issues/1654 (related discussion
  for CVE-2026-42945, same root cause: Photon's nginx package pinned
  to an outdated version)

## Testing
Not build-tested locally; relying on CI to validate the RPM build.
Change is metadata/version-only, no source patches modified.