### PR TITLE
aide 0.19-3: require libgcrypt >= 1.10.4 on subrelease 91+

### DIFF
--- a/SPECS/aide/aide.spec
+++ b/SPECS/aide/aide.spec
@@ -1,7 +1,7 @@
 Summary:        Intrusion detection environment
 Name:           aide
 Version:        0.19
-Release:        2%{?dist}
+Release:        3%{?dist}
 URL:            https://github.com/aide/aide
 Group:          System Environment/Base
 Vendor:         VMware, Inc.
@@ -37,7 +37,20 @@ BuildRequires: check-devel
 Requires: pcre2
 Requires: libgpg-error
 Requires: openssl
+# libgcrypt must be at least the version aide is built against. The
+# auto-generated soname dependency (libgcrypt.so.20(GCRYPT_1.6)) is satisfied by
+# 1.10.1 as well, so an unversioned Requires lets an already-installed 1.10.1
+# satisfy the install and libgcrypt is never upgraded. The stig-hardening role
+# works around that by running "tdnf -y install aide libgcrypt" by hand
+# (tasks/photon.yml, "Currently a bug in the aide package that does not upgrade
+# libgcrypt to the needed version"). Expressing it here removes the need for the
+# workaround. Guarded because libgcrypt is 1.10.4 only for subrelease >= 91;
+# subrelease <= 90 ships SPECS/90/libgcrypt at 1.10.1.
+%if 0%{photon_subrelease} >= 91
+Requires: libgcrypt >= 1.10.4
+%else
 Requires: libgcrypt
+%endif
 Requires: audit
 Requires: libacl
 Requires: attr
@@ -99,6 +112,8 @@ rm -rf %{buildroot}/*
 %{_var}/log/%{name}
 
 %changelog
+* Mon Aug 31 2026 Daniel Casota <dcasota@gmail.com> 0.19-3
+- Require libgcrypt >= 1.10.4 so it is upgraded rather than left at 1.10.1
 * Wed Mar 11 2026 Brennan Lamoreaux <brennan.lamoreaux@broadcom.com> 0.19-2
 - Migrate from pcre to pcre2
 * Tue Oct 07 2025 Harinadh Dommaraju <harinadh.dommaraju@broadcom.com> 0.19-1


### PR DESCRIPTION
Fixes the packaging gap that photon-os-installer was working around.

## Problem
`aide` links against libgcrypt but declares only an unversioned `Requires: libgcrypt`. Because nothing pinned a floor, `stigenable.py` listed `libgcrypt` explicitly in `KS_STIG_PACKAGES` purely to guarantee a new enough copy reached the install media — an installer-side workaround for a spec-side omission.

## Change
A `photon_subrelease`-guarded versioned dependency:

```spec
%if 0%{photon_subrelease} >= 91
Requires: libgcrypt >= 1.10.4
%else
Requires: libgcrypt
%endif
```

Release 2 → 3.

## Verification
`rpmspec` on both sides of the guard:

| subrelease | emitted requires |
|---|---|
| 90 | `libgcrypt` |
| 92 | `libgcrypt >= 1.10.4` |

Zero warnings in both cases; `support/spec-checker/check_spec.py` exits 0.

## Related
Counterpart to the photon-os-installer change, which drops `libgcrypt` from `KS_STIG_PACKAGES` now that the dependency is expressed where it belongs. Verified on a live install: libgcrypt-1.10.4-2 still lands on the media and on the installed system as an ordinary transitive dependency of aide.
